### PR TITLE
add michaelfeil/bge-small as default model

### DIFF
--- a/docs/benchmarks/simple_app.py
+++ b/docs/benchmarks/simple_app.py
@@ -23,7 +23,7 @@ USE_INFINITY = BENCHMARK_NAME == "infinity"
 DEVICE = os.environ.get("DEVICE", "cpu")
 
 # load large for cuda, small for cpu. (benchmarking large on cpu takes too long)
-MODEL_NAME = "BAAI/bge-small-en-v1.5" if DEVICE == "cpu" else "BAAI/bge-large-en-v1.5"
+MODEL_NAME = "michaelfeil/bge-small-en-v1.5" if DEVICE == "cpu" else "BAAI/bge-large-en-v1.5"
 
 # model loading
 

--- a/libs/infinity_emb/infinity_emb/args.py
+++ b/libs/infinity_emb/infinity_emb/args.py
@@ -13,7 +13,7 @@ class EngineArgs:
     """Creating a Async EmbeddingEngine object.
 
     Args:
-        model_name_or_path, str:  Defaults to "BAAI/bge-small-en-v1.5".
+        model_name_or_path, str:  Defaults to "michaelfeil/bge-small-en-v1.5".
         batch_size, int: Defaults to 64.
         revision, str: Defaults to None.
         trust_remote_code, bool: Defaults to True.
@@ -26,7 +26,7 @@ class EngineArgs:
         lengths_via_tokenize, bool: schedule by token usage. Defaults to False
     """
 
-    model_name_or_path: str = "BAAI/bge-small-en-v1.5"
+    model_name_or_path: str = "michaelfeil/bge-small-en-v1.5"
     batch_size: int = 64
     revision: Optional[str] = None
     trust_remote_code: bool = True

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -193,7 +193,7 @@ def create_server(
 
 
 def _start_uvicorn(
-    model_name_or_path: str = "BAAI/bge-small-en-v1.5",
+    model_name_or_path: str = "michaelfeil/bge-small-en-v1.5",
     batch_size: int = 64,
     revision: Optional[str] = None,
     trust_remote_code: bool = True,
@@ -212,7 +212,7 @@ def _start_uvicorn(
 
     Args:
         model_name_or_path, str: Huggingface model, e.g.
-            "BAAI/bge-small-en-v1.5".
+            "michaelfeil/bge-small-en-v1.5".
         batch_size, int: batch size for forward pass.
         revision: str: revision of the model.
         trust_remote_code, bool: trust remote code.

--- a/libs/infinity_emb/tests/conftest.py
+++ b/libs/infinity_emb/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 import pytest
 from sentence_transformers import InputExample, util  # type: ignore
 
-pytest.DEFAULT_BERT_MODEL = "BAAI/bge-small-en-v1.5"
+pytest.DEFAULT_BERT_MODEL = "michaelfeil/bge-small-en-v1.5"
 
 
 @pytest.fixture

--- a/libs/infinity_emb/tests/end_to_end/test_fastembed.py
+++ b/libs/infinity_emb/tests/end_to_end/test_fastembed.py
@@ -8,7 +8,7 @@ from infinity_emb.args import EngineArgs
 from infinity_emb.primitives import Device, InferenceEngine
 
 PREFIX = "/v1_fastembed"
-MODEL: str = "BAAI/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
+MODEL: str = "michaelfeil/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
 
 batch_size = 8
 

--- a/libs/infinity_emb/tests/end_to_end/test_fastembed.py
+++ b/libs/infinity_emb/tests/end_to_end/test_fastembed.py
@@ -8,9 +8,7 @@ from infinity_emb.args import EngineArgs
 from infinity_emb.primitives import Device, InferenceEngine
 
 PREFIX = "/v1_fastembed"
-MODEL: str = (
-    "michaelfeil/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
-)
+MODEL: str = "BAAI/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
 
 batch_size = 8
 

--- a/libs/infinity_emb/tests/end_to_end/test_fastembed.py
+++ b/libs/infinity_emb/tests/end_to_end/test_fastembed.py
@@ -8,7 +8,9 @@ from infinity_emb.args import EngineArgs
 from infinity_emb.primitives import Device, InferenceEngine
 
 PREFIX = "/v1_fastembed"
-MODEL: str = "michaelfeil/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
+MODEL: str = (
+    "michaelfeil/bge-small-en-v1.5"  #  pytest.DEFAULT_BERT_MODEL  # type: ignore
+)
 
 batch_size = 8
 

--- a/libs/infinity_emb/tests/unit_test/inference/test_models.py
+++ b/libs/infinity_emb/tests/unit_test/inference/test_models.py
@@ -54,8 +54,8 @@ def _pretrained_model_score(
         ("sentence-transformers/all-MiniLM-L6-v2", 82.03, "default"),
         ("sentence-transformers/all-MiniLM-L6-v2", 81.73, "int8"),
         ("sentence-transformers/all-MiniLM-L6-v2", 82.03, "default"),
-        ("BAAI/bge-small-en-v1.5", 86.00, None),
-        ("BAAI/bge-small-en-v1.5", 86.00, "int8"),
+        ("michaelfeil/bge-small-en-v1.5", 86.00, None),
+        ("michaelfeil/bge-small-en-v1.5", 86.00, "int8"),
     ],
 )
 def test_bert(get_sts_bechmark_dataset, model, score, compute_type):

--- a/libs/infinity_emb/tests/unit_test/inference/test_select_model.py
+++ b/libs/infinity_emb/tests/unit_test/inference/test_select_model.py
@@ -11,8 +11,8 @@ def test_engine(engine):
         EngineArgs(
             engine=engine,
             model_name_or_path=(
-                "TaylorAI/bge-micro-v2"
-                if engine == InferenceEngine.optimum
+                "BAAI/bge-small-en-v1.5"
+                if engine == InferenceEngine.fastembed
                 else pytest.DEFAULT_BERT_MODEL
             ),
             batch_size=4,

--- a/libs/infinity_emb/tests/unit_test/test_args.py
+++ b/libs/infinity_emb/tests/unit_test/test_args.py
@@ -8,7 +8,7 @@ def test_EngineArgs_no_input():
 
 def test_engine_args():
     args = EngineArgs(
-        model_name_or_path="BAAI/bge-small-en-v1.5",
+        model_name_or_path="michaelfeil/bge-small-en-v1.5",
         batch_size=64,
         revision=None,
         trust_remote_code=True,
@@ -19,7 +19,7 @@ def test_engine_args():
         lengths_via_tokenize=False,
     )
 
-    assert args.model_name_or_path == "BAAI/bge-small-en-v1.5"
+    assert args.model_name_or_path == "michaelfeil/bge-small-en-v1.5"
     assert args.batch_size == 64
     assert args.revision is None
     assert args.trust_remote_code

--- a/libs/infinity_emb/tests/unit_test/test_engine.py
+++ b/libs/infinity_emb/tests/unit_test/test_engine.py
@@ -28,7 +28,7 @@ async def test_async_api_torch():
     sentences = ["Hi", "how"]
     engine = AsyncEmbeddingEngine.from_args(
         EngineArgs(
-            model_name_or_path="BAAI/bge-small-en-v1.5",
+            model_name_or_path="michaelfeil/bge-small-en-v1.5",
             engine=InferenceEngine.torch,
             revision="main",
             device="cpu",
@@ -219,7 +219,7 @@ async def test_async_api_failing_revision():
         # revision with just Readme.
         AsyncEmbeddingEngine.from_args(
             EngineArgs(
-                model_name_or_path="BAAI/bge-small-en-v1.5",
+                model_name_or_path="michaelfeil/bge-small-en-v1.5",
                 revision="a32952c6d05d45f64f9f709a092c00839bcfe70a",
             )
         )

--- a/libs/infinity_emb/tests/unit_test/test_engine.py
+++ b/libs/infinity_emb/tests/unit_test/test_engine.py
@@ -183,6 +183,7 @@ async def test_async_api_fastembed():
     sentences = ["Hi", "how"]
     engine = AsyncEmbeddingEngine.from_args(
         EngineArgs(
+            model_name_or_path="BAAI/bge-small-en-v1.5",
             engine=InferenceEngine.fastembed,
             device="cpu",
             model_warmup=False,
@@ -219,7 +220,7 @@ async def test_async_api_failing_revision():
         # revision with just Readme.
         AsyncEmbeddingEngine.from_args(
             EngineArgs(
-                model_name_or_path="michaelfeil/bge-small-en-v1.5",
+                model_name_or_path="BAAI/bge-small-en-v1.5",
                 revision="a32952c6d05d45f64f9f709a092c00839bcfe70a",
             )
         )


### PR DESCRIPTION
This just adds michaelfeil/bge-small-en-v1.5 - it contains a stable version and quantized onnx files of the upstream.