### PR TITLE
Add revision and trust_remote_code to from_pretrained calls

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
+++ b/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
@@ -35,6 +35,7 @@ class SentenceClassifier(BaseClassifer):
 
         self._infinity_tokenizer = AutoTokenizer.from_pretrained(
             engine_args.model_name_or_path,
+            revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
 

--- a/libs/infinity_emb/infinity_emb/transformer/crossencoder/optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/crossencoder/optimum.py
@@ -40,14 +40,18 @@ class OptimumCrossEncoder(BaseCrossEncoder):
             file_name=onnx_file.as_posix(),
             optimize_model=not os.environ.get("INFINITY_ONNX_DISABLE_OPTIMIZE", False),
             model_class=ORTModelForSequenceClassification,
+            revision=engine_args.revision,
+            trust_remote_code=engine_args.trust_remote_code,
         )
         self.model.use_io_binding = False
         self.tokenizer = AutoTokenizer.from_pretrained(
             engine_args.model_name_or_path,
+            revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
         self.config = AutoConfig.from_pretrained(
             engine_args.model_name_or_path,
+            revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
         self._infinity_tokenizer = copy.deepcopy(self.tokenizer)

--- a/libs/infinity_emb/infinity_emb/transformer/embedder/neuron.py
+++ b/libs/infinity_emb/infinity_emb/transformer/embedder/neuron.py
@@ -82,8 +82,16 @@ class NeuronOptimumEmbedder(BaseEmbedder):
             else cls_token_pooling
         )
 
-        self.tokenizer = AutoTokenizer.from_pretrained(engine_args.model_name_or_path)
-        self.config = AutoConfig.from_pretrained(engine_args.model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            engine_args.model_name_or_path,
+            revision=engine_args.revision,
+            trust_remote_code=engine_args.trust_remote_code,
+        )
+        self.config = AutoConfig.from_pretrained(
+            engine_args.model_name_or_path,
+            revision=engine_args.revision,
+            trust_remote_code=engine_args.trust_remote_code,
+        )
         self._infinity_tokenizer = copy.deepcopy(self.tokenizer)
 
         compiler_args = {"num_cores": get_nc_count(), "auto_cast_type": "fp16"}
@@ -97,6 +105,8 @@ class NeuronOptimumEmbedder(BaseEmbedder):
         }
         self.model = NeuronModelForFeatureExtraction.from_pretrained(
             model_id=engine_args.model_name_or_path,
+            revision=engine_args.revision,
+            trust_remote_code=engine_args.trust_remote_code,
             export=True,
             **compiler_args,
             **input_shapes,

--- a/libs/infinity_emb/infinity_emb/transformer/embedder/optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/embedder/optimum.py
@@ -50,6 +50,8 @@ class OptimumEmbedder(BaseEmbedder):
 
         self.model = optimize_model(
             model_name_or_path=engine_args.model_name_or_path,
+            revision=engine_args.revision,
+            trust_remote_code=engine_args.trust_remote_code,
             execution_provider=provider,
             file_name=onnx_file.as_posix(),
             optimize_model=not os.environ.get("INFINITY_ONNX_DISABLE_OPTIMIZE", False),
@@ -59,10 +61,12 @@ class OptimumEmbedder(BaseEmbedder):
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             engine_args.model_name_or_path,
+            revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
         self.config = AutoConfig.from_pretrained(
             engine_args.model_name_or_path,
+            revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
         self._infinity_tokenizer = copy.deepcopy(self.tokenizer)

--- a/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
@@ -70,6 +70,7 @@ def optimize_model(
     file_name: str,
     optimize_model=False,
     revision: Optional[str] = None,
+    trust_remote_code: bool = True,
 ):
     CHECK_ONNXRUNTIME.mark_required()
     path_folder = (
@@ -82,6 +83,7 @@ def optimize_model(
         return model_class.from_pretrained(
             model_name_or_path,
             revision=revision,
+            trust_remote_code=trust_remote_code,
             provider=execution_provider,
             file_name=file_name,
             provider_options={
@@ -100,15 +102,17 @@ def optimize_model(
         return model_class.from_pretrained(
             file_optimized.parent.as_posix(),
             revision=revision,
+            trust_remote_code=trust_remote_code,
             provider=execution_provider,
             file_name=file_optimized.name,
         )
 
     unoptimized_model_path = model_class.from_pretrained(
         model_name_or_path,
+        revision=revision,
+        trust_remote_code=trust_remote_code,
         provider=execution_provider,
         file_name=file_name,
-        revision=revision,
     )
     if not optimize_model or execution_provider == "TensorrtExecutionProvider":
         return unoptimized_model_path
@@ -137,6 +141,8 @@ def optimize_model(
 
         model = model_class.from_pretrained(
             optimized_model_path,
+            revision=engine_args.revision,
+            trust_remote_code=trust_remote_code,
             provider=execution_provider,
             file_name=Path(file_name).name.replace(".onnx", "_optimized.onnx"),
         )

--- a/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
@@ -141,7 +141,7 @@ def optimize_model(
 
         model = model_class.from_pretrained(
             optimized_model_path,
-            revision=engine_args.revision,
+            revision=revision,
             trust_remote_code=trust_remote_code,
             provider=execution_provider,
             file_name=Path(file_name).name.replace(".onnx", "_optimized.onnx"),


### PR DESCRIPTION
I was trying out `Snowflake/snowflake-arctic-embed-m-long` with onnx engine

```
infinity_emb --model-name-or-path Snowflake/snowflake-arctic-embed-m-long --revision 08e7a4449e3f07709fb9387bc3172d393a6cc5e2 --engine optimum --device cpu --dtype float32 --batch-size 4 --port 8000 --trust-remote-code 
```

But trust_remote_code is not being passed along

```
  File "/app/infinity_emb/transformer/embedder/optimum.py", line 51, in __init__
    self.model = optimize_model(
  File "/app/infinity_emb/transformer/utils_optimum.py", line 107, in optimize_model
    unoptimized_model_path = model_class.from_pretrained(
  File "/app/.venv/lib/python3.10/site-packages/optimum/onnxruntime/modeling_ort.py", line 669, in from_pretrained
    return super().from_pretrained(
  File "/app/.venv/lib/python3.10/site-packages/optimum/modeling_base.py", line 373, in from_pretrained
    config = cls._load_config(
  File "/app/.venv/lib/python3.10/site-packages/optimum/modeling_base.py", line 231, in _load_config
    config = AutoConfig.from_pretrained(
  File "/app/.venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 1141, in from_pretrained
    trust_remote_code = resolve_trust_remote_code(
  File "/app/.venv/lib/python3.10/site-packages/transformers/dynamic_module_utils.py", line 622, in resolve_trust_remote_code
    raise ValueError(
ValueError: Loading Snowflake/snowflake-arctic-embed-m-long requires you to execute the configuration file in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
```