### PR TITLE
Add support to pass `root_path` to FastAPI app

### DIFF
--- a/libs/infinity_emb/infinity_emb/args.py
+++ b/libs/infinity_emb/infinity_emb/args.py
@@ -90,9 +90,11 @@ class EngineArgs:
             object.__setattr__(
                 self,
                 "vector_disk_cache_path",
-                f"{self.engine}_{self.model_name_or_path.replace('/','_')}"
-                if self.vector_disk_cache_path
-                else "",
+                (
+                    f"{self.engine}_{self.model_name_or_path.replace('/','_')}"
+                    if self.vector_disk_cache_path
+                    else ""
+                ),
             )
 
         # after all done -> check if the dataclass is valid

--- a/libs/infinity_emb/infinity_emb/env.py
+++ b/libs/infinity_emb/infinity_emb/env.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from infinity_emb.primitives import (
     Device,
@@ -41,7 +41,7 @@ class __Infinity_EnvManager:
     def _to_name(name: str) -> str:
         return "INFINITY_" + name.upper().replace("-", "_")
 
-    def _optional_infinity_var(self, name: str, default: str = ""):
+    def _optional_infinity_var(self, name: str, default: Any = ""):
         name = self._to_name(name)
         value = os.getenv(name)
         if value is None:
@@ -182,6 +182,10 @@ class __Infinity_EnvManager:
     @cached_property
     def url_prefix(self):
         return self._optional_infinity_var("url_prefix", default="")
+
+    @cached_property
+    def root_path(self):
+        return self._optional_infinity_var("root_path", default=None)
 
     @cached_property
     def port(self):

--- a/libs/infinity_emb/infinity_emb/env.py
+++ b/libs/infinity_emb/infinity_emb/env.py
@@ -184,8 +184,8 @@ class __Infinity_EnvManager:
         return self._optional_infinity_var("url_prefix", default="")
 
     @cached_property
-    def root_path(self):
-        return self._optional_infinity_var("root_path", default="")
+    def proxy_root_path(self):
+        return self._optional_infinity_var("proxy_root_path", default="")
 
     @cached_property
     def port(self):

--- a/libs/infinity_emb/infinity_emb/env.py
+++ b/libs/infinity_emb/infinity_emb/env.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from infinity_emb.primitives import (
     Device,
@@ -41,7 +41,7 @@ class __Infinity_EnvManager:
     def _to_name(name: str) -> str:
         return "INFINITY_" + name.upper().replace("-", "_")
 
-    def _optional_infinity_var(self, name: str, default: Any = ""):
+    def _optional_infinity_var(self, name: str, default: str = ""):
         name = self._to_name(name)
         value = os.getenv(name)
         if value is None:
@@ -185,7 +185,7 @@ class __Infinity_EnvManager:
 
     @cached_property
     def root_path(self):
-        return self._optional_infinity_var("root_path", default=None)
+        return self._optional_infinity_var("root_path", default="")
 
     @cached_property
     def port(self):

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -40,7 +40,7 @@ def create_server(
     preload_only: bool = MANAGER.preload_only,
     permissive_cors: bool = MANAGER.permissive_cors,
     api_key: str = MANAGER.api_key,
-    root_path: Optional[str] = None,
+    root_path: str = MANAGER.root_path,
 ):
     """
     creates the FastAPI App
@@ -527,7 +527,7 @@ if CHECK_TYPER.is_available:
         log_level: UVICORN_LOG_LEVELS = MANAGER.log_level,  # type: ignore
         permissive_cors: bool = False,
         api_key: str = "",
-        root_path: Optional[str] = MANAGER.root_path,
+        root_path: str = MANAGER.root_path,
     ):
         """Infinity API ♾️ cli v2
         MIT License; Copyright (c) 2023-now Michael Feil

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -469,7 +469,9 @@ if CHECK_TYPER.is_available:
             port, int: port that you want to expose.
         """
         if api_key:
-            raise ValueError("api_key is not supported in `v1`. Please migrate to `v2`.")
+            raise ValueError(
+                "api_key is not supported in `v1`. Please migrate to `v2`."
+            )
         logger.warning(
             "CLI v1 is deprecated and might be removed in the future. Please use CLI v2, by specifying `v2` as the command."
         )

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -40,7 +40,7 @@ def create_server(
     preload_only: bool = MANAGER.preload_only,
     permissive_cors: bool = MANAGER.permissive_cors,
     api_key: str = MANAGER.api_key,
-    root_path: str = MANAGER.root_path,
+    proxy_root_path: str = MANAGER.proxy_root_path,
 ):
     """
     creates the FastAPI App
@@ -89,7 +89,7 @@ def create_server(
             "identifier": "MIT",
         },
         lifespan=lifespan,
-        root_path=root_path,
+        root_path=proxy_root_path,
     )
     route_dependencies = []
 
@@ -469,7 +469,7 @@ if CHECK_TYPER.is_available:
             port, int: port that you want to expose.
         """
         if api_key:
-            raise ValueError("api_key is not supported in v1")
+            raise ValueError("api_key is not supported in `v1`. Please migrate to `v2`.")
         logger.warning(
             "CLI v1 is deprecated and might be removed in the future. Please use CLI v2, by specifying `v2` as the command."
         )
@@ -527,7 +527,7 @@ if CHECK_TYPER.is_available:
         log_level: UVICORN_LOG_LEVELS = MANAGER.log_level,  # type: ignore
         permissive_cors: bool = False,
         api_key: str = "",
-        root_path: str = MANAGER.root_path,
+        proxy_root_path: str = MANAGER.proxy_root_path,
     ):
         """Infinity API ♾️ cli v2
         MIT License; Copyright (c) 2023-now Michael Feil
@@ -560,7 +560,7 @@ if CHECK_TYPER.is_available:
             preload_only, bool: only preload the model and exit. Defaults to False.
             permissive_cors, bool: add permissive CORS headers to enable consumption from a browser. Defaults to False.
             api_key, str: optional Bearer token for authentication. Defaults to "", which disables authentication.
-            root_path, str: optional Proxy prefix for the application. See: https://fastapi.tiangolo.com/advanced/behind-a-proxy/
+            proxy_root_path, str: optional Proxy prefix for the application. See: https://fastapi.tiangolo.com/advanced/behind-a-proxy/
         """
         logger.setLevel(log_level.to_int())
         padder = AutoPadding(
@@ -594,7 +594,7 @@ if CHECK_TYPER.is_available:
             preload_only=preload_only,
             permissive_cors=permissive_cors,
             api_key=api_key,
-            root_path=root_path,
+            proxy_root_path=proxy_root_path,
         )
         uvicorn.run(app, host=host, port=port, log_level=log_level.name)
 

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -40,6 +40,7 @@ def create_server(
     preload_only: bool = MANAGER.preload_only,
     permissive_cors: bool = MANAGER.permissive_cors,
     api_key: str = MANAGER.api_key,
+    root_path: Optional[str] = None,
 ):
     """
     creates the FastAPI App
@@ -88,6 +89,7 @@ def create_server(
             "identifier": "MIT",
         },
         lifespan=lifespan,
+        root_path=root_path,
     )
     route_dependencies = []
 
@@ -525,6 +527,7 @@ if CHECK_TYPER.is_available:
         log_level: UVICORN_LOG_LEVELS = MANAGER.log_level,  # type: ignore
         permissive_cors: bool = False,
         api_key: str = "",
+        root_path: Optional[str] = MANAGER.root_path,
     ):
         """Infinity API ♾️ cli v2
         MIT License; Copyright (c) 2023-now Michael Feil
@@ -557,6 +560,7 @@ if CHECK_TYPER.is_available:
             preload_only, bool: only preload the model and exit. Defaults to False.
             permissive_cors, bool: add permissive CORS headers to enable consumption from a browser. Defaults to False.
             api_key, str: optional Bearer token for authentication. Defaults to "", which disables authentication.
+            root_path, str: optional Proxy prefix for the application. See: https://fastapi.tiangolo.com/advanced/behind-a-proxy/
         """
         logger.setLevel(log_level.to_int())
         padder = AutoPadding(
@@ -590,6 +594,7 @@ if CHECK_TYPER.is_available:
             preload_only=preload_only,
             permissive_cors=permissive_cors,
             api_key=api_key,
+            root_path=root_path,
         )
         uvicorn.run(app, host=host, port=port, log_level=log_level.name)
 

--- a/libs/infinity_emb/infinity_emb/primitives.py
+++ b/libs/infinity_emb/infinity_emb/primitives.py
@@ -3,6 +3,7 @@ Definition of enums and dataclasses used in the library.
 
 Do not import infinity_emb from this file, as it will cause a circular import.
 """
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
When behind some proxy like nginx, Traefik, Istio, the app might be behind some prefix that is unknown to the app. Without knowing the prefix swagger UI cannot send requests to the correct location. Passing the prefix via `root_path` corrects the server value in openapi
See https://fastapi.tiangolo.com/advanced/behind-a-proxy/

---

On a side note, I am wondering if there is a way to configure miscellaneous fastapi and uvicorn options via external env or config files instead of having infinity take the burden of passing them along