### PR TITLE
update client

### DIFF
--- a/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings.py
+++ b/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings.py
@@ -74,7 +74,7 @@ def sync_detailed(
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
     r"""Embeddings
 
-     Encode Embeddings. Supports with multimodal inputs.
+     Encode Embeddings. Supports with multimodal inputs. Aligned with OpenAI Embeddings API.
 
     ## Running Text Embeddings
     ```python
@@ -94,7 +94,7 @@ def sync_detailed(
                 # can also be base64 encoded
             ],
             # set extra modality to image to process as image
-            \"infinity_extra_modality\": \"image\"
+            \"modality\": \"image\"
     )
     ```
 
@@ -120,7 +120,7 @@ def sync_detailed(
                 url, url_to_base64(url, \"audio\")
             ],
             # set extra modality to audio to process as audio
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
     ```
@@ -134,7 +134,7 @@ def sync_detailed(
         input=[url_to_base64(url, \"audio\")],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
 
@@ -143,7 +143,7 @@ def sync_detailed(
         input=[\"the sound of a beep\", \"the sound of a cat\"],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"text\"
+            \"modality\": \"text\"
         }
     )
     ```
@@ -184,7 +184,7 @@ def sync(
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
     r"""Embeddings
 
-     Encode Embeddings. Supports with multimodal inputs.
+     Encode Embeddings. Supports with multimodal inputs. Aligned with OpenAI Embeddings API.
 
     ## Running Text Embeddings
     ```python
@@ -204,7 +204,7 @@ def sync(
                 # can also be base64 encoded
             ],
             # set extra modality to image to process as image
-            \"infinity_extra_modality\": \"image\"
+            \"modality\": \"image\"
     )
     ```
 
@@ -230,7 +230,7 @@ def sync(
                 url, url_to_base64(url, \"audio\")
             ],
             # set extra modality to audio to process as audio
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
     ```
@@ -244,7 +244,7 @@ def sync(
         input=[url_to_base64(url, \"audio\")],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
 
@@ -253,7 +253,7 @@ def sync(
         input=[\"the sound of a beep\", \"the sound of a cat\"],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"text\"
+            \"modality\": \"text\"
         }
     )
     ```
@@ -289,7 +289,7 @@ async def asyncio_detailed(
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
     r"""Embeddings
 
-     Encode Embeddings. Supports with multimodal inputs.
+     Encode Embeddings. Supports with multimodal inputs. Aligned with OpenAI Embeddings API.
 
     ## Running Text Embeddings
     ```python
@@ -309,7 +309,7 @@ async def asyncio_detailed(
                 # can also be base64 encoded
             ],
             # set extra modality to image to process as image
-            \"infinity_extra_modality\": \"image\"
+            \"modality\": \"image\"
     )
     ```
 
@@ -335,7 +335,7 @@ async def asyncio_detailed(
                 url, url_to_base64(url, \"audio\")
             ],
             # set extra modality to audio to process as audio
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
     ```
@@ -349,7 +349,7 @@ async def asyncio_detailed(
         input=[url_to_base64(url, \"audio\")],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
 
@@ -358,7 +358,7 @@ async def asyncio_detailed(
         input=[\"the sound of a beep\", \"the sound of a cat\"],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"text\"
+            \"modality\": \"text\"
         }
     )
     ```
@@ -397,7 +397,7 @@ async def asyncio(
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
     r"""Embeddings
 
-     Encode Embeddings. Supports with multimodal inputs.
+     Encode Embeddings. Supports with multimodal inputs. Aligned with OpenAI Embeddings API.
 
     ## Running Text Embeddings
     ```python
@@ -417,7 +417,7 @@ async def asyncio(
                 # can also be base64 encoded
             ],
             # set extra modality to image to process as image
-            \"infinity_extra_modality\": \"image\"
+            \"modality\": \"image\"
     )
     ```
 
@@ -443,7 +443,7 @@ async def asyncio(
                 url, url_to_base64(url, \"audio\")
             ],
             # set extra modality to audio to process as audio
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
     ```
@@ -457,7 +457,7 @@ async def asyncio(
         input=[url_to_base64(url, \"audio\")],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"audio\"
+            \"modality\": \"audio\"
         }
     )
 
@@ -466,7 +466,7 @@ async def asyncio(
         input=[\"the sound of a beep\", \"the sound of a cat\"],
         encoding_format= \"base64\",
         extra_body={
-            \"infinity_extra_modality\": \"text\"
+            \"modality\": \"text\"
         }
     )
     ```

--- a/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings_audio.py
+++ b/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings_audio.py
@@ -64,7 +64,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     body: AudioEmbeddingInput,
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `audio`
+    r"""Deprecated: Use `embeddings` with `modality` set to `audio`
 
      Encode Embeddings from Audio files
 
@@ -84,7 +84,7 @@ def sync_detailed(
     ```
 
     Args:
-        body (AudioEmbeddingInput): # LEGACY
+        body (AudioEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -110,7 +110,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     body: AudioEmbeddingInput,
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `audio`
+    r"""Deprecated: Use `embeddings` with `modality` set to `audio`
 
      Encode Embeddings from Audio files
 
@@ -130,7 +130,7 @@ def sync(
     ```
 
     Args:
-        body (AudioEmbeddingInput): # LEGACY
+        body (AudioEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -151,7 +151,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     body: AudioEmbeddingInput,
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `audio`
+    r"""Deprecated: Use `embeddings` with `modality` set to `audio`
 
      Encode Embeddings from Audio files
 
@@ -171,7 +171,7 @@ async def asyncio_detailed(
     ```
 
     Args:
-        body (AudioEmbeddingInput): # LEGACY
+        body (AudioEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -195,7 +195,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     body: AudioEmbeddingInput,
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `audio`
+    r"""Deprecated: Use `embeddings` with `modality` set to `audio`
 
      Encode Embeddings from Audio files
 
@@ -215,7 +215,7 @@ async def asyncio(
     ```
 
     Args:
-        body (AudioEmbeddingInput): # LEGACY
+        body (AudioEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings_image.py
+++ b/libs/client_infinity/infinity_client/infinity_client/api/default/embeddings_image.py
@@ -64,7 +64,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     body: ImageEmbeddingInput,
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `image`
+    r"""Deprecated: Use `embeddings` with `modality` set to `image`
 
      Encode Embeddings from Image files
 
@@ -83,7 +83,7 @@ def sync_detailed(
     ```
 
     Args:
-        body (ImageEmbeddingInput): # LEGACY
+        body (ImageEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -109,7 +109,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     body: ImageEmbeddingInput,
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `image`
+    r"""Deprecated: Use `embeddings` with `modality` set to `image`
 
      Encode Embeddings from Image files
 
@@ -128,7 +128,7 @@ def sync(
     ```
 
     Args:
-        body (ImageEmbeddingInput): # LEGACY
+        body (ImageEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -149,7 +149,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     body: ImageEmbeddingInput,
 ) -> Response[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `image`
+    r"""Deprecated: Use `embeddings` with `modality` set to `image`
 
      Encode Embeddings from Image files
 
@@ -168,7 +168,7 @@ async def asyncio_detailed(
     ```
 
     Args:
-        body (ImageEmbeddingInput): # LEGACY
+        body (ImageEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -192,7 +192,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     body: ImageEmbeddingInput,
 ) -> Optional[Union[HTTPValidationError, OpenAIEmbeddingResult]]:
-    r"""Deprecated: Use `embeddings` with `infinity_extra_modality` set to `image`
+    r"""Deprecated: Use `embeddings` with `modality` set to `image`
 
      Encode Embeddings from Image files
 
@@ -211,7 +211,7 @@ async def asyncio(
     ```
 
     Args:
-        body (ImageEmbeddingInput): # LEGACY
+        body (ImageEmbeddingInput): LEGACY, DO NO LONGER UPDATE
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/libs/client_infinity/infinity_client/infinity_client/api/default/rerank.py
+++ b/libs/client_infinity/infinity_client/infinity_client/api/default/rerank.py
@@ -66,7 +66,7 @@ def sync_detailed(
 ) -> Response[Union[HTTPValidationError, ReRankResult]]:
     r"""Rerank
 
-     Rerank documents
+     Rerank documents. Aligned with Cohere API (https://docs.cohere.com/reference/rerank)
 
     ```python
     import requests
@@ -107,7 +107,7 @@ def sync(
 ) -> Optional[Union[HTTPValidationError, ReRankResult]]:
     r"""Rerank
 
-     Rerank documents
+     Rerank documents. Aligned with Cohere API (https://docs.cohere.com/reference/rerank)
 
     ```python
     import requests
@@ -143,7 +143,7 @@ async def asyncio_detailed(
 ) -> Response[Union[HTTPValidationError, ReRankResult]]:
     r"""Rerank
 
-     Rerank documents
+     Rerank documents. Aligned with Cohere API (https://docs.cohere.com/reference/rerank)
 
     ```python
     import requests
@@ -182,7 +182,7 @@ async def asyncio(
 ) -> Optional[Union[HTTPValidationError, ReRankResult]]:
     r"""Rerank
 
-     Rerank documents
+     Rerank documents. Aligned with Cohere API (https://docs.cohere.com/reference/rerank)
 
     ```python
     import requests

--- a/libs/client_infinity/infinity_client/infinity_client/models/__init__.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/__init__.py
@@ -14,11 +14,11 @@ from .model_info import ModelInfo
 from .model_info_object import ModelInfoObject
 from .model_info_owned_by import ModelInfoOwnedBy
 from .open_ai_embedding_input_audio import OpenAIEmbeddingInputAudio
-from .open_ai_embedding_input_audio_infinity_extra_modality import OpenAIEmbeddingInputAudioInfinityExtraModality
+from .open_ai_embedding_input_audio_modality import OpenAIEmbeddingInputAudioModality
 from .open_ai_embedding_input_image import OpenAIEmbeddingInputImage
-from .open_ai_embedding_input_image_infinity_extra_modality import OpenAIEmbeddingInputImageInfinityExtraModality
+from .open_ai_embedding_input_image_modality import OpenAIEmbeddingInputImageModality
 from .open_ai_embedding_input_text import OpenAIEmbeddingInputText
-from .open_ai_embedding_input_text_infinity_extra_modality import OpenAIEmbeddingInputTextInfinityExtraModality
+from .open_ai_embedding_input_text_modality import OpenAIEmbeddingInputTextModality
 from .open_ai_embedding_result import OpenAIEmbeddingResult
 from .open_ai_embedding_result_object import OpenAIEmbeddingResultObject
 from .open_ai_model_info import OpenAIModelInfo
@@ -46,11 +46,11 @@ __all__ = (
     "ModelInfoObject",
     "ModelInfoOwnedBy",
     "OpenAIEmbeddingInputAudio",
-    "OpenAIEmbeddingInputAudioInfinityExtraModality",
+    "OpenAIEmbeddingInputAudioModality",
     "OpenAIEmbeddingInputImage",
-    "OpenAIEmbeddingInputImageInfinityExtraModality",
+    "OpenAIEmbeddingInputImageModality",
     "OpenAIEmbeddingInputText",
-    "OpenAIEmbeddingInputTextInfinityExtraModality",
+    "OpenAIEmbeddingInputTextModality",
     "OpenAIEmbeddingResult",
     "OpenAIEmbeddingResultObject",
     "OpenAIModelInfo",

--- a/libs/client_infinity/infinity_client/infinity_client/models/audio_embedding_input.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/audio_embedding_input.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="AudioEmbeddingInput")
 
 @_attrs_define
 class AudioEmbeddingInput:
-    """# LEGACY
+    """LEGACY, DO NO LONGER UPDATE
 
     Attributes:
         input_ (Union[List[str], str]):

--- a/libs/client_infinity/infinity_client/infinity_client/models/image_embedding_input.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/image_embedding_input.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="ImageEmbeddingInput")
 
 @_attrs_define
 class ImageEmbeddingInput:
-    """# LEGACY
+    """LEGACY, DO NO LONGER UPDATE
 
     Attributes:
         input_ (Union[List[str], str]):

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_audio.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_audio.py
@@ -4,9 +4,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.embedding_encoding_format import EmbeddingEncodingFormat
-from ..models.open_ai_embedding_input_audio_infinity_extra_modality import (
-    OpenAIEmbeddingInputAudioInfinityExtraModality,
-)
+from ..models.open_ai_embedding_input_audio_modality import OpenAIEmbeddingInputAudioModality
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="OpenAIEmbeddingInputAudio")
@@ -20,17 +18,14 @@ class OpenAIEmbeddingInputAudio:
         model (Union[Unset, str]):  Default: 'default/not-specified'.
         encoding_format (Union[Unset, EmbeddingEncodingFormat]):
         user (Union[None, Unset, str]):
-        infinity_extra_modality (Union[Unset, OpenAIEmbeddingInputAudioInfinityExtraModality]):  Default:
-            OpenAIEmbeddingInputAudioInfinityExtraModality.AUDIO.
+        modality (Union[Unset, OpenAIEmbeddingInputAudioModality]):  Default: OpenAIEmbeddingInputAudioModality.AUDIO.
     """
 
     input_: Union[List[str], str]
     model: Union[Unset, str] = "default/not-specified"
     encoding_format: Union[Unset, EmbeddingEncodingFormat] = UNSET
     user: Union[None, Unset, str] = UNSET
-    infinity_extra_modality: Union[
-        Unset, OpenAIEmbeddingInputAudioInfinityExtraModality
-    ] = OpenAIEmbeddingInputAudioInfinityExtraModality.AUDIO
+    modality: Union[Unset, OpenAIEmbeddingInputAudioModality] = OpenAIEmbeddingInputAudioModality.AUDIO
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -57,9 +52,9 @@ class OpenAIEmbeddingInputAudio:
         else:
             user = self.user
 
-        infinity_extra_modality: Union[Unset, str] = UNSET
-        if not isinstance(self.infinity_extra_modality, Unset):
-            infinity_extra_modality = self.infinity_extra_modality.value
+        modality: Union[Unset, str] = UNSET
+        if not isinstance(self.modality, Unset):
+            modality = self.modality.value
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -74,8 +69,8 @@ class OpenAIEmbeddingInputAudio:
             field_dict["encoding_format"] = encoding_format
         if user is not UNSET:
             field_dict["user"] = user
-        if infinity_extra_modality is not UNSET:
-            field_dict["infinity_extra_modality"] = infinity_extra_modality
+        if modality is not UNSET:
+            field_dict["modality"] = modality
 
         return field_dict
 
@@ -123,19 +118,19 @@ class OpenAIEmbeddingInputAudio:
 
         user = _parse_user(d.pop("user", UNSET))
 
-        _infinity_extra_modality = d.pop("infinity_extra_modality", UNSET)
-        infinity_extra_modality: Union[Unset, OpenAIEmbeddingInputAudioInfinityExtraModality]
-        if isinstance(_infinity_extra_modality, Unset):
-            infinity_extra_modality = UNSET
+        _modality = d.pop("modality", UNSET)
+        modality: Union[Unset, OpenAIEmbeddingInputAudioModality]
+        if isinstance(_modality, Unset):
+            modality = UNSET
         else:
-            infinity_extra_modality = OpenAIEmbeddingInputAudioInfinityExtraModality(_infinity_extra_modality)
+            modality = OpenAIEmbeddingInputAudioModality(_modality)
 
         open_ai_embedding_input_audio = cls(
             input_=input_,
             model=model,
             encoding_format=encoding_format,
             user=user,
-            infinity_extra_modality=infinity_extra_modality,
+            modality=modality,
         )
 
         open_ai_embedding_input_audio.additional_properties = d

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_audio_modality.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_audio_modality.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class OpenAIEmbeddingInputAudioInfinityExtraModality(str, Enum):
+class OpenAIEmbeddingInputAudioModality(str, Enum):
     AUDIO = "audio"
 
     def __str__(self) -> str:

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_image.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_image.py
@@ -4,9 +4,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.embedding_encoding_format import EmbeddingEncodingFormat
-from ..models.open_ai_embedding_input_image_infinity_extra_modality import (
-    OpenAIEmbeddingInputImageInfinityExtraModality,
-)
+from ..models.open_ai_embedding_input_image_modality import OpenAIEmbeddingInputImageModality
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="OpenAIEmbeddingInputImage")
@@ -20,17 +18,14 @@ class OpenAIEmbeddingInputImage:
         model (Union[Unset, str]):  Default: 'default/not-specified'.
         encoding_format (Union[Unset, EmbeddingEncodingFormat]):
         user (Union[None, Unset, str]):
-        infinity_extra_modality (Union[Unset, OpenAIEmbeddingInputImageInfinityExtraModality]):  Default:
-            OpenAIEmbeddingInputImageInfinityExtraModality.IMAGE.
+        modality (Union[Unset, OpenAIEmbeddingInputImageModality]):  Default: OpenAIEmbeddingInputImageModality.IMAGE.
     """
 
     input_: Union[List[str], str]
     model: Union[Unset, str] = "default/not-specified"
     encoding_format: Union[Unset, EmbeddingEncodingFormat] = UNSET
     user: Union[None, Unset, str] = UNSET
-    infinity_extra_modality: Union[
-        Unset, OpenAIEmbeddingInputImageInfinityExtraModality
-    ] = OpenAIEmbeddingInputImageInfinityExtraModality.IMAGE
+    modality: Union[Unset, OpenAIEmbeddingInputImageModality] = OpenAIEmbeddingInputImageModality.IMAGE
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -57,9 +52,9 @@ class OpenAIEmbeddingInputImage:
         else:
             user = self.user
 
-        infinity_extra_modality: Union[Unset, str] = UNSET
-        if not isinstance(self.infinity_extra_modality, Unset):
-            infinity_extra_modality = self.infinity_extra_modality.value
+        modality: Union[Unset, str] = UNSET
+        if not isinstance(self.modality, Unset):
+            modality = self.modality.value
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -74,8 +69,8 @@ class OpenAIEmbeddingInputImage:
             field_dict["encoding_format"] = encoding_format
         if user is not UNSET:
             field_dict["user"] = user
-        if infinity_extra_modality is not UNSET:
-            field_dict["infinity_extra_modality"] = infinity_extra_modality
+        if modality is not UNSET:
+            field_dict["modality"] = modality
 
         return field_dict
 
@@ -123,19 +118,19 @@ class OpenAIEmbeddingInputImage:
 
         user = _parse_user(d.pop("user", UNSET))
 
-        _infinity_extra_modality = d.pop("infinity_extra_modality", UNSET)
-        infinity_extra_modality: Union[Unset, OpenAIEmbeddingInputImageInfinityExtraModality]
-        if isinstance(_infinity_extra_modality, Unset):
-            infinity_extra_modality = UNSET
+        _modality = d.pop("modality", UNSET)
+        modality: Union[Unset, OpenAIEmbeddingInputImageModality]
+        if isinstance(_modality, Unset):
+            modality = UNSET
         else:
-            infinity_extra_modality = OpenAIEmbeddingInputImageInfinityExtraModality(_infinity_extra_modality)
+            modality = OpenAIEmbeddingInputImageModality(_modality)
 
         open_ai_embedding_input_image = cls(
             input_=input_,
             model=model,
             encoding_format=encoding_format,
             user=user,
-            infinity_extra_modality=infinity_extra_modality,
+            modality=modality,
         )
 
         open_ai_embedding_input_image.additional_properties = d

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_image_modality.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_image_modality.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 
-class OpenAIEmbeddingInputTextInfinityExtraModality(str, Enum):
-    TEXT = "text"
+class OpenAIEmbeddingInputImageModality(str, Enum):
+    IMAGE = "image"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_text.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_text.py
@@ -4,7 +4,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.embedding_encoding_format import EmbeddingEncodingFormat
-from ..models.open_ai_embedding_input_text_infinity_extra_modality import OpenAIEmbeddingInputTextInfinityExtraModality
+from ..models.open_ai_embedding_input_text_modality import OpenAIEmbeddingInputTextModality
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="OpenAIEmbeddingInputText")
@@ -19,17 +19,14 @@ class OpenAIEmbeddingInputText:
         model (Union[Unset, str]):  Default: 'default/not-specified'.
         encoding_format (Union[Unset, EmbeddingEncodingFormat]):
         user (Union[None, Unset, str]):
-        infinity_extra_modality (Union[Unset, OpenAIEmbeddingInputTextInfinityExtraModality]):  Default:
-            OpenAIEmbeddingInputTextInfinityExtraModality.TEXT.
+        modality (Union[Unset, OpenAIEmbeddingInputTextModality]):  Default: OpenAIEmbeddingInputTextModality.TEXT.
     """
 
     input_: Union[List[str], str]
     model: Union[Unset, str] = "default/not-specified"
     encoding_format: Union[Unset, EmbeddingEncodingFormat] = UNSET
     user: Union[None, Unset, str] = UNSET
-    infinity_extra_modality: Union[
-        Unset, OpenAIEmbeddingInputTextInfinityExtraModality
-    ] = OpenAIEmbeddingInputTextInfinityExtraModality.TEXT
+    modality: Union[Unset, OpenAIEmbeddingInputTextModality] = OpenAIEmbeddingInputTextModality.TEXT
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -52,9 +49,9 @@ class OpenAIEmbeddingInputText:
         else:
             user = self.user
 
-        infinity_extra_modality: Union[Unset, str] = UNSET
-        if not isinstance(self.infinity_extra_modality, Unset):
-            infinity_extra_modality = self.infinity_extra_modality.value
+        modality: Union[Unset, str] = UNSET
+        if not isinstance(self.modality, Unset):
+            modality = self.modality.value
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -69,8 +66,8 @@ class OpenAIEmbeddingInputText:
             field_dict["encoding_format"] = encoding_format
         if user is not UNSET:
             field_dict["user"] = user
-        if infinity_extra_modality is not UNSET:
-            field_dict["infinity_extra_modality"] = infinity_extra_modality
+        if modality is not UNSET:
+            field_dict["modality"] = modality
 
         return field_dict
 
@@ -109,19 +106,19 @@ class OpenAIEmbeddingInputText:
 
         user = _parse_user(d.pop("user", UNSET))
 
-        _infinity_extra_modality = d.pop("infinity_extra_modality", UNSET)
-        infinity_extra_modality: Union[Unset, OpenAIEmbeddingInputTextInfinityExtraModality]
-        if isinstance(_infinity_extra_modality, Unset):
-            infinity_extra_modality = UNSET
+        _modality = d.pop("modality", UNSET)
+        modality: Union[Unset, OpenAIEmbeddingInputTextModality]
+        if isinstance(_modality, Unset):
+            modality = UNSET
         else:
-            infinity_extra_modality = OpenAIEmbeddingInputTextInfinityExtraModality(_infinity_extra_modality)
+            modality = OpenAIEmbeddingInputTextModality(_modality)
 
         open_ai_embedding_input_text = cls(
             input_=input_,
             model=model,
             encoding_format=encoding_format,
             user=user,
-            infinity_extra_modality=infinity_extra_modality,
+            modality=modality,
         )
 
         open_ai_embedding_input_text.additional_properties = d

--- a/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_text_modality.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/open_ai_embedding_input_text_modality.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 
-class OpenAIEmbeddingInputImageInfinityExtraModality(str, Enum):
-    IMAGE = "image"
+class OpenAIEmbeddingInputTextModality(str, Enum):
+    TEXT = "text"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/libs/client_infinity/infinity_client/infinity_client/models/rerank_input.py
+++ b/libs/client_infinity/infinity_client/infinity_client/models/rerank_input.py
@@ -18,6 +18,7 @@ class RerankInput:
         return_documents (Union[Unset, bool]):  Default: False.
         raw_scores (Union[Unset, bool]):  Default: False.
         model (Union[Unset, str]):  Default: 'default/not-specified'.
+        top_n (Union[None, Unset, int]):
     """
 
     query: str
@@ -25,6 +26,7 @@ class RerankInput:
     return_documents: Union[Unset, bool] = False
     raw_scores: Union[Unset, bool] = False
     model: Union[Unset, str] = "default/not-specified"
+    top_n: Union[None, Unset, int] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -37,6 +39,12 @@ class RerankInput:
         raw_scores = self.raw_scores
 
         model = self.model
+
+        top_n: Union[None, Unset, int]
+        if isinstance(self.top_n, Unset):
+            top_n = UNSET
+        else:
+            top_n = self.top_n
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -52,6 +60,8 @@ class RerankInput:
             field_dict["raw_scores"] = raw_scores
         if model is not UNSET:
             field_dict["model"] = model
+        if top_n is not UNSET:
+            field_dict["top_n"] = top_n
 
         return field_dict
 
@@ -68,12 +78,22 @@ class RerankInput:
 
         model = d.pop("model", UNSET)
 
+        def _parse_top_n(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        top_n = _parse_top_n(d.pop("top_n", UNSET))
+
         rerank_input = cls(
             query=query,
             documents=documents,
             return_documents=return_documents,
             raw_scores=raw_scores,
             model=model,
+            top_n=top_n,
         )
 
         rerank_input.additional_properties = d

--- a/libs/client_infinity/infinity_client/pyproject.toml
+++ b/libs/client_infinity/infinity_client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infinity_client"
-version = "0.0.58"
+version = "0.0.62"
 description = "A client library for accessing ♾️ Infinity - Embedding Inference Server"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
This pull request includes several changes to the `libs/client_infinity/infinity_client/infinity_client/api/default/embeddings.py`, `embeddings_audio.py`, and `embeddings_image.py` files. The primary changes involve updating the terminology from "infinity_extra_modality" to "modality" and aligning the documentation with the OpenAI Embeddings API.

### Terminology Update:
* Updated the key from `"infinity_extra_modality"` to `"modality"` in various functions to standardize the terminology. (`embeddings.py`, `embeddings_audio.py`, `embeddings_image.py`) [[1]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL97-R97) [[2]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL123-R123) [[3]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL137-R137) [[4]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL146-R146) [[5]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL207-R207) [[6]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL233-R233) [[7]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL247-R247) [[8]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL256-R256) [[9]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL312-R312) [[10]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL338-R338) [[11]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL352-R352) [[12]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL361-R361) [[13]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL420-R420) [[14]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL446-R446) [[15]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL460-R460) [[16]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL469-R469) [[17]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L67-R67) [[18]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L113-R113) [[19]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L154-R154) [[20]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L198-R198) [[21]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL67-R67) [[22]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL112-R112) [[23]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL152-R152) [[24]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL195-R195)

### Documentation Alignment:
* Updated the documentation to indicate alignment with the OpenAI Embeddings API. (`embeddings.py`) [[1]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL77-R77) [[2]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL187-R187) [[3]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL292-R292) [[4]](diffhunk://#diff-5317a207f6a2c2238c754af46a067a7c2dc00ade0ae292f30bd727bb5f81bc2fL400-R400)

### Deprecation Notice:
* Added a deprecation notice for legacy functions, indicating that the `AudioEmbeddingInput` and `ImageEmbeddingInput` should no longer be updated. (`embeddings_audio.py`, `embeddings_image.py`) [[1]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L87-R87) [[2]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L133-R133) [[3]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L174-R174) [[4]](diffhunk://#diff-913c4956f7e2118afcd64229911decf35976681662c42bbb439d89e9f8e0bd25L218-R218) [[5]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL86-R86) [[6]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL131-R131) [[7]](diffhunk://#diff-63260c8b16c0d02f7ad2ee6fabe35122a937f8cf8325d5b67b9b179530c81b8fL171-R171)

These changes ensure consistency in terminology and improve the clarity of the documentation, aligning it with the OpenAI Embeddings API.