### PR TITLE
improve typing to 3.9 standards

### DIFF
--- a/libs/infinity_emb/infinity_emb/engine.py
+++ b/libs/infinity_emb/infinity_emb/engine.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023-now michaelfeilfeil
 
 from asyncio import Semaphore
-from typing import Iterable, Iterator, List, Optional, Set, Union
+from typing import Iterable, Iterator, Optional, Union
 
 from infinity_emb.args import EngineArgs
 
@@ -122,7 +122,7 @@ class AsyncEmbeddingEngine:
         return self.running
 
     @property
-    def capabilities(self) -> Set[ModelCapabilites]:
+    def capabilities(self) -> set[ModelCapabilites]:
         return self._model.capabilities
 
     @property
@@ -214,7 +214,7 @@ class AsyncEmbeddingEngine:
         return scores, usage
 
     async def image_embed(
-        self, *, images: List[Union[str, "ImageClassType", bytes]]
+        self, *, images: list[Union[str, "ImageClassType", bytes]]
     ) -> tuple[list["EmbeddingReturnType"], int]:
         """embed multiple images
 
@@ -237,7 +237,7 @@ class AsyncEmbeddingEngine:
         return embeddings, usage
 
     async def audio_embed(
-        self, *, audios: List[Union[str, bytes]]
+        self, *, audios: list[Union[str, bytes]]
     ) -> tuple[list["EmbeddingReturnType"], int]:
         """embed multiple audios
 
@@ -383,7 +383,7 @@ class AsyncEngineArray:
         return await self[model].classify(sentences=sentences, raw_scores=raw_scores)
 
     async def image_embed(
-        self, *, model: str, images: List[Union[str, "ImageClassType"]]
+        self, *, model: str, images: list[Union[str, "ImageClassType"]]
     ) -> tuple[list["EmbeddingReturnType"], int]:
         """embed multiple images
 

--- a/libs/infinity_emb/infinity_emb/fastapi_schemas/data_uri.py
+++ b/libs/infinity_emb/infinity_emb/fastapi_schemas/data_uri.py
@@ -5,7 +5,7 @@ import textwrap
 from base64 import b64decode as decode64
 from base64 import b64encode as encode64
 from dataclasses import dataclass
-from typing import Any, Dict, MutableMapping, Optional, Tuple, TypeVar, Union
+from typing import Any, MutableMapping, Optional, TypeVar, Union
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -162,7 +162,7 @@ class DataURI(str):
     @property
     def _parse(
         self,
-    ) -> Tuple[Optional[str], Optional[str], Optional[str], bool, bytes]:
+    ) -> tuple[Optional[str], Optional[str], Optional[str], bool, bytes]:
         match = _DATA_URI_RE.match(self)
         if match is None:
             raise InvalidDataURI("Not a valid data URI: %r" % self)
@@ -228,7 +228,7 @@ class DataURI(str):
         return json_schema
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+    def __modify_schema__(cls, field_schema: dict[str, Any]) -> None:
         # __modify_schema__ should mutate the dict it receives in place,
         # the returned value will be ignored
         field_schema.update(

--- a/libs/infinity_emb/infinity_emb/inference/batch_handler.py
+++ b/libs/infinity_emb/infinity_emb/inference/batch_handler.py
@@ -9,7 +9,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
-from typing import Any, List, Optional, Sequence, Set, Union
+from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 
@@ -228,7 +228,7 @@ class BatchHandler:
     async def image_embed(
         self,
         *,
-        images: List[Union[str, "ImageClassType", bytes]],
+        images: list[Union[str, "ImageClassType", bytes]],
     ) -> tuple[list["EmbeddingReturnType"], int]:
         """Schedule a images and sentences to be embedded. Awaits until embedded.
 
@@ -257,7 +257,7 @@ class BatchHandler:
     async def audio_embed(
         self,
         *,
-        audios: List[Union[str, bytes]],
+        audios: list[Union[str, bytes]],
     ) -> tuple[list["EmbeddingReturnType"], int]:
         """Schedule audios and sentences to be embedded. Awaits until embedded.
 
@@ -310,7 +310,7 @@ class BatchHandler:
         return result, usage
 
     @property
-    def capabilities(self) -> Set[ModelCapabilites]:
+    def capabilities(self) -> set[ModelCapabilites]:
         # TODO: try to remove inheritance here and return upon init.
         return self.model_worker.capabilities
 
@@ -447,7 +447,7 @@ class ModelWorker:
         self._threadpool.submit(self._postprocess_batch)
 
     @property
-    def capabilities(self) -> Set[ModelCapabilites]:
+    def capabilities(self) -> set[ModelCapabilites]:
         return self._model.capabilities
 
     def tokenize_lengths(self, *args, **kwargs):

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -7,7 +7,7 @@ import signal
 import sys
 import time
 from contextlib import asynccontextmanager
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import infinity_emb
 from infinity_emb._optional_imports import CHECK_TYPER, CHECK_UVICORN
@@ -204,8 +204,8 @@ def create_server(
         return engine
 
     def _resolve_mixed_input(
-        inputs: Union[DataURIorURL, List[DataURIorURL]]
-    ) -> List[Union[str, bytes]]:
+        inputs: Union[DataURIorURL, list[DataURIorURL]]
+    ) -> list[Union[str, bytes]]:
         if hasattr(inputs, "host"):
             # if it is a single url
             urls_or_bytes: list[Union[str, bytes]] = [str(inputs)]

--- a/libs/infinity_emb/infinity_emb/sync_engine.py
+++ b/libs/infinity_emb/infinity_emb/sync_engine.py
@@ -12,7 +12,6 @@ from typing import (
     Awaitable,
     Callable,
     Iterator,
-    List,
     Optional,
     TypeVar,
     Union,
@@ -213,7 +212,7 @@ class SyncEngineArray(WeakAsyncLifeMixin):
         )
 
     @add_start_docstrings(AsyncEngineArray.image_embed.__doc__)
-    def image_embed(self, *, model: str, images: List[Union[str, ImageClassType]]):
+    def image_embed(self, *, model: str, images: list[Union[str, ImageClassType]]):
         """sync interface of AsyncEngineArray"""
         return self.async_run(
             self.async_engine_array.image_embed, model=model, images=images

--- a/libs/infinity_emb/infinity_emb/transformer/abstract.py
+++ b/libs/infinity_emb/infinity_emb/transformer/abstract.py
@@ -4,7 +4,7 @@
 import random
 from abc import ABC, abstractmethod
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Set, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from infinity_emb._optional_imports import CHECK_PIL  # , CHECK_SOUNDFILE
 from infinity_emb.primitives import (
@@ -42,7 +42,7 @@ if CHECK_PIL.is_available:
 
 
 class BaseTransformer(ABC):  # Inherit from ABC(Abstract base class)
-    capabilities: Set[ModelCapabilites] = set()
+    capabilities: set[ModelCapabilites] = set()
     engine_args: "EngineArgs"
 
     @abstractmethod  # Decorator to define an abstract method

--- a/libs/infinity_emb/infinity_emb/transformer/vision/utils.py
+++ b/libs/infinity_emb/infinity_emb/transformer/vision/utils.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import io
-from typing import List, Union
+from typing import Union
 
 from infinity_emb._optional_imports import CHECK_AIOHTTP, CHECK_PIL
 from infinity_emb.primitives import (
@@ -76,8 +76,8 @@ async def resolve_image(
 
 
 async def resolve_images(
-    images: List[Union[str, "ImageClassType", bytes]]
-) -> List[ImageSingle]:
+    images: list[Union[str, "ImageClassType", bytes]]
+) -> list[ImageSingle]:
     """Resolve images from URLs or ImageClassType Objects using multithreading."""
     # TODO: improve parallel requests, safety, error handling
     CHECK_AIOHTTP.mark_required()


### PR DESCRIPTION
This pull request focuses on updating type annotations to use the new built-in generic types introduced in Python 3.9, such as `list` and `set`, instead of the older `List` and `Set` from the `typing` module. The most important changes include updates to type annotations in various functions and methods across multiple files.

### Type Annotation Updates:

* `libs/infinity_emb/infinity_emb/engine.py`
  * Updated type annotations for `capabilities` property and various methods to use `set` and `list` instead of `Set` and `List`. [[1]](diffhunk://#diff-48a6c4c12cfc12b3f7633856035e8ec40c8aa7ade76e3cf5bda26b62426598a2L125-R125) [[2]](diffhunk://#diff-48a6c4c12cfc12b3f7633856035e8ec40c8aa7ade76e3cf5bda26b62426598a2L217-R217) [[3]](diffhunk://#diff-48a6c4c12cfc12b3f7633856035e8ec40c8aa7ade76e3cf5bda26b62426598a2L240-R240) [[4]](diffhunk://#diff-48a6c4c12cfc12b3f7633856035e8ec40c8aa7ade76e3cf5bda26b62426598a2L386-R386)

* `libs/infinity_emb/infinity_emb/fastapi_schemas/data_uri.py`
  * Updated type annotations in methods to use `dict` and `tuple` instead of `Dict` and `Tuple`. [[1]](diffhunk://#diff-917c73b9d082aab41f2e6b49f69c35a07e7ba53dafd926e359d41662702aaf2eL8-R8) [[2]](diffhunk://#diff-917c73b9d082aab41f2e6b49f69c35a07e7ba53dafd926e359d41662702aaf2eL165-R165) [[3]](diffhunk://#diff-917c73b9d082aab41f2e6b49f69c35a07e7ba53dafd926e359d41662702aaf2eL231-R231)

* `libs/infinity_emb/infinity_emb/inference/batch_handler.py`
  * Updated type annotations for `capabilities` property and various methods to use `set` and `list` instead of `Set` and `List`. [[1]](diffhunk://#diff-0a1f9df7c044ef3a2871175c063f0e50e8569d9b3cd80c91ba389223fc0a1ea0L12-R12) [[2]](diffhunk://#diff-0a1f9df7c044ef3a2871175c063f0e50e8569d9b3cd80c91ba389223fc0a1ea0L231-R231) [[3]](diffhunk://#diff-0a1f9df7c044ef3a2871175c063f0e50e8569d9b3cd80c91ba389223fc0a1ea0L260-R260) [[4]](diffhunk://#diff-0a1f9df7c044ef3a2871175c063f0e50e8569d9b3cd80c91ba389223fc0a1ea0L313-R313) [[5]](diffhunk://#diff-0a1f9df7c044ef3a2871175c063f0e50e8569d9b3cd80c91ba389223fc0a1ea0L450-R450)

* `libs/infinity_emb/infinity_emb/infinity_server.py`
  * Updated type annotations in methods to use `list` instead of `List`. [[1]](diffhunk://#diff-dbce95f93a1407eaa94de1552d808ed309b50751fc5f6e274e07c6a8cab7701eL10-R10) [[2]](diffhunk://#diff-dbce95f93a1407eaa94de1552d808ed309b50751fc5f6e274e07c6a8cab7701eL207-R208)

* `libs/infinity_emb/infinity_emb/sync_engine.py`
  * Removed unused `List` import and updated type annotations in methods to use `list` instead of `List`. [[1]](diffhunk://#diff-f4dd281db624d1c6358641217502a04def063bee181c7dc1796f71cf6747e621L15) [[2]](diffhunk://#diff-f4dd281db624d1c6358641217502a04def063bee181c7dc1796f71cf6747e621L216-R215)

* `libs/infinity_emb/infinity_emb/transformer/abstract.py`
  * Updated type annotations for `capabilities` property to use `set` instead of `Set`. [[1]](diffhunk://#diff-9df50b032699e04f13ce7bb94920f5df7de2065a08fbb58bc6b83f94199f21f3L7-R7) [[2]](diffhunk://#diff-9df50b032699e04f13ce7bb94920f5df7de2065a08fbb58bc6b83f94199f21f3L45-R45)

* `libs/infinity_emb/infinity_emb/transformer/vision/utils.py`
  * Updated type annotations in method to use `list` instead of `List`. [[1]](diffhunk://#diff-a47efc277753063b843bf0543182a00f1918f50424d5f9b28877956bef7b4f19L6-R6) [[2]](diffhunk://#diff-a47efc277753063b843bf0543182a00f1918f50424d5f9b28877956bef7b4f19L79-R80)