### PR TITLE
[AMD] [ROCm] [Optimum] Add optimum-amd support

### DIFF
--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -21,6 +21,38 @@ docker run -it --gpus all \
 ```
 The cache path at inside the docker container is set by the environment variable `HF_HOME`.
 
+
+### AMD Docker: Deploy on AMD Platform (MI200 Series and MI300 Series) 
+#### Launch the CLI using a pre-built docker container (recommended) 
+
+```bash
+port=7997
+model1=michaelfeil/bge-small-en-v1.5
+model2=mixedbread-ai/mxbai-rerank-xsmall-v1
+volume=$PWD/data
+
+docker run -it \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --network host \
+  -v $volume:/app/.cache \
+  -p $port:$port \
+  michaelf34/infinity:latest-rocm \
+  v2 \
+  --model-id $model1 \
+  --model-id $model2 \
+  --port $port \
+  --engine torch \
+  --compile \
+  --no-bettertransformer
+```
+The cache path at inside the docker container is set by the environment variable `HF_HOME`.
+
+
+
 ## Modal Labs
 
 A deployment example for usage within are located at repo, including a Github Actions Pipeline.

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -49,6 +49,8 @@ amd:
         && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
         && python -m pip uninstall onnxruntime -y \
         && python -m pip install build/Linux/Release/dist/* \
+        && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+        && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
         && git clone https://github.com/huggingface/optimum-amd.git \
         && cd optimum-amd \
         && python -m pip install -e .; \

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -30,41 +30,44 @@ amd:
     COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
     RUN ./requirements_install_from_poetry.sh --no-root --without lint,test "https://download.pytorch.org/whl/rocm6.2"
   extra_installs_main: | 
-    ARG GPU_ARCH
-    ENV GPU_ARCH=${GPU_ARCH}
+    # ARG GPU_ARCH
+    # ENV GPU_ARCH=${GPU_ARCH}
     # GPU architecture specific installations
     RUN cd /opt/rocm/share/amd_smi \
     && python -m pip wheel . --wheel-dir=/install
     RUN apt update -y && apt install migraphx -y
-    RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
-        # OPTION1: Follow the steps here to install onnxruntime-rocm 
-        # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-        . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-        && python -m pip install /install/*.whl \
-        && python -m pip install cmake onnx \
-        && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-        && (. $HOME/.cargo/env) \
-        && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-        && cd onnxruntime \
-        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
-        && python -m pip uninstall onnxruntime -y \
-        && python -m pip install build/Linux/Release/dist/* \
-        && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
-        && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
-        && git clone https://github.com/huggingface/optimum-amd.git \
-        && cd optimum-amd \
-        && python -m pip install -e .; \
-    elif [ "$GPU_ARCH" = "gfx1100" ]; then \
-        # OPTION2: Install onnxruntime-rocm from the wheel
-        . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
-        && python -m pip install /install/*.whl \
-        && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
-        && cd /tmp-optimum \
-        && python -m pip install .; \
-    else \
-        echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
-        exit 1; \
-    fi
+    # RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+    #     # OPTION1: Follow the steps here to install onnxruntime-rocm 
+    #     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+    #     . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+    #     && python -m pip install /install/*.whl \
+    #     && python -m pip install cmake onnx \
+    #     && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+    #     && (. $HOME/.cargo/env) \
+    #     && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+    #     && cd onnxruntime \
+    #     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
+    #     && python -m pip uninstall onnxruntime -y \
+    #     && python -m pip install build/Linux/Release/dist/* \
+    #     && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+    #     && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
+    #     && git clone https://github.com/huggingface/optimum-amd.git \
+    #     && cd optimum-amd \
+    #     && python -m pip install -e .; \
+    # elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+    ## Interestingly the radeon onnxruntime-rocm works on mi300x and it has the same performance as
+    ## compiling the onnxruntime-rocm from source targeting mi300x build.
+    ## This zero performance gain could be related to this issue (https://github.com/huggingface/optimum-amd/issues/163)
+    # OPTION2: Install onnxruntime-rocm from the wheel 
+    RUN . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+    && python -m pip install /install/*.whl \
+    && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+    && cd /tmp-optimum \
+    && python -m pip install .;
+    # else \
+    #     echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+    #     exit 1; \
+    # fi
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -32,22 +32,22 @@ amd:
   extra_installs_main: | 
     # OPTION1: Follow the steps here to install onnxruntime-rocm 
     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-    RUN python3 -m pip uninstall onnxruntime \
-      && python3 -m pip install cmake onnx \
-      && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-      && (. $HOME/.cargo/env)
-    RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-        && cd onnxruntime \
-        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
-        && python3 -m pip install build/Linux/Release/dist/* 
-    RUN git clone https://github.com/huggingface/optimum-amd.git \
-        && cd optimum-amd \
-        && pip install -e . 
-    # OPTION2: Install onnxruntime-rocm from the wheel
-    # RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
+    # RUN python3 -m pip uninstall onnxruntime \
+    #   && python3 -m pip install cmake onnx \
+    #   && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+    #   && (. $HOME/.cargo/env)
+    # RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+    #     && cd onnxruntime \
+    #     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+    #     && python3 -m pip install build/Linux/Release/dist/* 
     # RUN git clone https://github.com/huggingface/optimum-amd.git \
     #     && cd optimum-amd \
     #     && pip install -e . 
+    # OPTION2: Install onnxruntime-rocm from the wheel
+    RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
+    RUN git clone https://github.com/huggingface/optimum-amd.git \
+        && cd optimum-amd \
+        && pip install -e . 
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -45,6 +45,9 @@ amd:
         && pip install -e . 
     # OPTION2: Install onnxruntime-rocm from the wheel
     # RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
+    # RUN git clone https://github.com/huggingface/optimum-amd.git \
+    #     && cd optimum-amd \
+    #     && pip install -e . 
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -29,8 +29,23 @@ amd:
     # "RUN poetry install --no-interaction --no-ansi --no-root --extras \"${EXTRAS}\" --without lint,test && poetry cache clear pypi --all"
     COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
     RUN ./requirements_install_from_poetry.sh --no-root --without lint,test "https://download.pytorch.org/whl/rocm6.2"
-
-  poetry_extras: "all onnxruntime-gpu"
+  extra_installs_main: | 
+    # OPTION1: Follow the steps here to install onnxruntime-rocm 
+    # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+    RUN python3 -m pip uninstall onnxruntime \
+      && python3 -m pip install cmake onnx \
+      && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+      && (. $HOME/.cargo/env)
+    RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+        && cd onnxruntime \
+        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+        && python3 -m pip install build/Linux/Release/dist/* 
+    RUN git clone https://github.com/huggingface/optimum-amd.git \
+        && cd optimum-amd \
+        && pip install -e . 
+    # OPTION2: Install onnxruntime-rocm from the wheel
+    # RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
+  poetry_extras: "all"
   python_version: python3.10
 
 trt:

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -31,18 +31,22 @@ amd:
     RUN ./requirements_install_from_poetry.sh --no-root --without lint,test "https://download.pytorch.org/whl/rocm6.2"
   extra_installs_main: | 
     ARG GPU_ARCH
+    ENV GPU_ARCH=${GPU_ARCH}
     # GPU architecture specific installations
+    RUN cd /opt/rocm/share/amd_smi \
+    && python -m pip wheel . --wheel-dir=/install
     RUN apt update -y && apt install migraphx -y
     RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
         # OPTION1: Follow the steps here to install onnxruntime-rocm 
         # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
         . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-        && python -m pip install cmake onnx -y \
+        && python -m pip install /install/*.whl \
+        && python -m pip install cmake onnx \
         && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
         && (. $HOME/.cargo/env) \
         && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
         && cd onnxruntime \
-        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
         && python -m pip uninstall onnxruntime -y \
         && python -m pip install build/Linux/Release/dist/* \
         && git clone https://github.com/huggingface/optimum-amd.git \
@@ -51,6 +55,7 @@ amd:
     elif [ "$GPU_ARCH" = "gfx1100" ]; then \
         # OPTION2: Install onnxruntime-rocm from the wheel
         . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+        && python -m pip install /install/*.whl \
         && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
         && cd /tmp-optimum \
         && python -m pip install .; \

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -30,44 +30,41 @@ amd:
     COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
     RUN ./requirements_install_from_poetry.sh --no-root --without lint,test "https://download.pytorch.org/whl/rocm6.2"
   extra_installs_main: | 
-    # ARG GPU_ARCH
-    # ENV GPU_ARCH=${GPU_ARCH}
+    ARG GPU_ARCH
+    ENV GPU_ARCH=${GPU_ARCH}
     # GPU architecture specific installations
     RUN cd /opt/rocm/share/amd_smi \
     && python -m pip wheel . --wheel-dir=/install
     RUN apt update -y && apt install migraphx -y
-    # RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
-    #     # OPTION1: Follow the steps here to install onnxruntime-rocm 
-    #     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-    #     . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-    #     && python -m pip install /install/*.whl \
-    #     && python -m pip install cmake onnx \
-    #     && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-    #     && (. $HOME/.cargo/env) \
-    #     && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-    #     && cd onnxruntime \
-    #     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
-    #     && python -m pip uninstall onnxruntime -y \
-    #     && python -m pip install build/Linux/Release/dist/* \
-    #     && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
-    #     && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
-    #     && git clone https://github.com/huggingface/optimum-amd.git \
-    #     && cd optimum-amd \
-    #     && python -m pip install -e .; \
-    # elif [ "$GPU_ARCH" = "gfx1100" ]; then \
-    ## Interestingly the radeon onnxruntime-rocm works on mi300x and it has the same performance as
-    ## compiling the onnxruntime-rocm from source targeting mi300x build.
-    ## This zero performance gain could be related to this issue (https://github.com/huggingface/optimum-amd/issues/163)
-    # OPTION2: Install onnxruntime-rocm from the wheel 
-    RUN . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
-    && python -m pip install /install/*.whl \
-    && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
-    && cd /tmp-optimum \
-    && python -m pip install .;
-    # else \
-    #     echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
-    #     exit 1; \
-    # fi
+    RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+        # OPTION1: Follow the steps here to install onnxruntime-rocm 
+        # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+        . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+        && python -m pip install /install/*.whl \
+        && python -m pip install cmake onnx \
+        && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+        && (. $HOME/.cargo/env) \
+        && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+        && cd onnxruntime \
+        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
+        && python -m pip uninstall onnxruntime -y \
+        && python -m pip install build/Linux/Release/dist/* \
+        && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+        && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
+        && git clone https://github.com/huggingface/optimum-amd.git \
+        && cd optimum-amd \
+        && python -m pip install -e .; \
+    elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+        # OPTION2: Install onnxruntime-rocm from the wheel
+        . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+        && python -m pip install /install/*.whl \
+        && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+        && cd /tmp-optimum \
+        && python -m pip install .; \
+    else \
+        echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+        exit 1; \
+    fi
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -45,9 +45,9 @@ amd:
     #     && pip install -e . 
     # OPTION2: Install onnxruntime-rocm from the wheel
     RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
-    RUN git clone https://github.com/huggingface/optimum-amd.git \
-        && cd optimum-amd \
-        && pip install -e . 
+    RUN git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+        && cd /tmp-optimum \
+        && pip install . 
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Docker.template.yaml
+++ b/libs/infinity_emb/Docker.template.yaml
@@ -30,24 +30,34 @@ amd:
     COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
     RUN ./requirements_install_from_poetry.sh --no-root --without lint,test "https://download.pytorch.org/whl/rocm6.2"
   extra_installs_main: | 
-    # OPTION1: Follow the steps here to install onnxruntime-rocm 
-    # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-    # RUN python3 -m pip uninstall onnxruntime \
-    #   && python3 -m pip install cmake onnx \
-    #   && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-    #   && (. $HOME/.cargo/env)
-    # RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-    #     && cd onnxruntime \
-    #     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
-    #     && python3 -m pip install build/Linux/Release/dist/* 
-    # RUN git clone https://github.com/huggingface/optimum-amd.git \
-    #     && cd optimum-amd \
-    #     && pip install -e . 
-    # OPTION2: Install onnxruntime-rocm from the wheel
-    RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
-    RUN git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+    ARG GPU_ARCH
+    # GPU architecture specific installations
+    RUN apt update -y && apt install migraphx -y
+    RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+        # OPTION1: Follow the steps here to install onnxruntime-rocm 
+        # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+        . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+        && python -m pip install cmake onnx -y \
+        && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+        && (. $HOME/.cargo/env) \
+        && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+        && cd onnxruntime \
+        && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+        && python -m pip uninstall onnxruntime -y \
+        && python -m pip install build/Linux/Release/dist/* \
+        && git clone https://github.com/huggingface/optimum-amd.git \
+        && cd optimum-amd \
+        && python -m pip install -e .; \
+    elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+        # OPTION2: Install onnxruntime-rocm from the wheel
+        . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+        && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
         && cd /tmp-optimum \
-        && pip install . 
+        && python -m pip install .; \
+    else \
+        echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+        exit 1; \
+    fi
   poetry_extras: "all"
   python_version: python3.10
 

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -47,6 +47,23 @@ COPY infinity_emb infinity_emb
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
+# Follow the steps here to install onnxruntime-rocm 
+# https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+RUN python3 -m pip uninstall onnxruntime \
+    && python3 -m pip install cmake onnx \
+    && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+    && (. $HOME/.cargo/env)
+
+RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+    && cd onnxruntime \
+    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+    && python3 -m pip install build/Linux/Release/dist/* \
+    && cd ..
+
+RUN git clone https://github.com/huggingface/optimum-amd.git \
+    && cd optimum-amd \
+    && pip install -e .
+
 #
 
 
@@ -56,9 +73,15 @@ FROM builder as testing
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --with lint,test "https://download.pytorch.org/whl/rocm6.2"
 
+RUN /app/.venv/bin/python -m pip uninstall onnxruntime -y \
+    && /app/.venv/bin/python -m pip install onnxruntime/build/Linux/Release/dist/* \
+    && cd optimum-amd \
+    && /app/.venv/bin/python -m pip install -e .
+
 # lint 
-RUN poetry run ruff check .
-RUN poetry run mypy .
+RUN poetry run ruff check . --exclude ./onnxruntime --exclude ./optimum-amd --exclude ./.venv
+RUN poetry run mypy . --exclude 'onnxruntime|optimum-amd|.venv'
+
 # pytest
 COPY tests tests
 # run end to end tests because of duration of build in github ci.
@@ -86,6 +109,12 @@ RUN echo "all tests passed" > "test_results.txt"
 # Use a multi-stage build -> production version, with download
 FROM base AS tested-builder
 COPY --from=builder /app /app
+
+RUN /app/.venv/bin/python -m pip uninstall onnxruntime -y \
+    && /app/.venv/bin/python -m pip install onnxruntime/build/Linux/Release/dist/* \
+    && cd optimum-amd \
+    && /app/.venv/bin/python -m pip install -e .
+    
 # force testing stage to run
 COPY --from=testing /app/test_results.txt /app/test_results.txt
 ENV HF_HOME=/app/.cache/huggingface

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -48,18 +48,22 @@ COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
 ARG GPU_ARCH
+ENV GPU_ARCH=${GPU_ARCH}
 # GPU architecture specific installations
+RUN cd /opt/rocm/share/amd_smi \
+&& python -m pip wheel . --wheel-dir=/install
 RUN apt update -y && apt install migraphx -y
 RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
     # OPTION1: Follow the steps here to install onnxruntime-rocm 
     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
     . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-    && python -m pip install cmake onnx -y \
+    && python -m pip install /install/*.whl \
+    && python -m pip install cmake onnx \
     && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
     && (. $HOME/.cargo/env) \
     && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
     && cd onnxruntime \
-    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
     && python -m pip uninstall onnxruntime -y \
     && python -m pip install build/Linux/Release/dist/* \
     && git clone https://github.com/huggingface/optimum-amd.git \
@@ -68,6 +72,7 @@ RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
 elif [ "$GPU_ARCH" = "gfx1100" ]; then \
     # OPTION2: Install onnxruntime-rocm from the wheel
     . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+    && python -m pip install /install/*.whl \
     && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
     && cd /tmp-optimum \
     && python -m pip install .; \

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -47,24 +47,34 @@ COPY infinity_emb infinity_emb
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
-# OPTION1: Follow the steps here to install onnxruntime-rocm 
-# https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-# RUN python3 -m pip uninstall onnxruntime \
-#   && python3 -m pip install cmake onnx \
-#   && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-#   && (. $HOME/.cargo/env)
-# RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-#     && cd onnxruntime \
-#     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
-#     && python3 -m pip install build/Linux/Release/dist/* 
-# RUN git clone https://github.com/huggingface/optimum-amd.git \
-#     && cd optimum-amd \
-#     && pip install -e . 
-# OPTION2: Install onnxruntime-rocm from the wheel
-RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
-RUN git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+ARG GPU_ARCH
+# GPU architecture specific installations
+RUN apt update -y && apt install migraphx -y
+RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+    # OPTION1: Follow the steps here to install onnxruntime-rocm 
+    # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+    . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+    && python -m pip install cmake onnx -y \
+    && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+    && (. $HOME/.cargo/env) \
+    && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+    && cd onnxruntime \
+    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+    && python -m pip uninstall onnxruntime -y \
+    && python -m pip install build/Linux/Release/dist/* \
+    && git clone https://github.com/huggingface/optimum-amd.git \
+    && cd optimum-amd \
+    && python -m pip install -e .; \
+elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+    # OPTION2: Install onnxruntime-rocm from the wheel
+    . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+    && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
     && cd /tmp-optimum \
-    && pip install . 
+    && python -m pip install .; \
+else \
+    echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+    exit 1; \
+fi
 
 
 

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -62,9 +62,9 @@ RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download
 #     && pip install -e . 
 # OPTION2: Install onnxruntime-rocm from the wheel
 RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
-RUN git clone https://github.com/huggingface/optimum-amd.git \
-    && cd optimum-amd \
-    && pip install -e . 
+RUN git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+    && cd /tmp-optimum \
+    && pip install . 
 
 
 

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -47,41 +47,44 @@ COPY infinity_emb infinity_emb
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
-ARG GPU_ARCH
-ENV GPU_ARCH=${GPU_ARCH}
+# ARG GPU_ARCH
+# ENV GPU_ARCH=${GPU_ARCH}
 # GPU architecture specific installations
 RUN cd /opt/rocm/share/amd_smi \
 && python -m pip wheel . --wheel-dir=/install
 RUN apt update -y && apt install migraphx -y
-RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
-    # OPTION1: Follow the steps here to install onnxruntime-rocm 
-    # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-    . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-    && python -m pip install /install/*.whl \
-    && python -m pip install cmake onnx \
-    && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-    && (. $HOME/.cargo/env) \
-    && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-    && cd onnxruntime \
-    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
-    && python -m pip uninstall onnxruntime -y \
-    && python -m pip install build/Linux/Release/dist/* \
-    && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
-    && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
-    && git clone https://github.com/huggingface/optimum-amd.git \
-    && cd optimum-amd \
-    && python -m pip install -e .; \
-elif [ "$GPU_ARCH" = "gfx1100" ]; then \
-    # OPTION2: Install onnxruntime-rocm from the wheel
-    . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
-    && python -m pip install /install/*.whl \
-    && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
-    && cd /tmp-optimum \
-    && python -m pip install .; \
-else \
-    echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
-    exit 1; \
-fi
+# RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+#     # OPTION1: Follow the steps here to install onnxruntime-rocm 
+#     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+#     . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+#     && python -m pip install /install/*.whl \
+#     && python -m pip install cmake onnx \
+#     && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+#     && (. $HOME/.cargo/env) \
+#     && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+#     && cd onnxruntime \
+#     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
+#     && python -m pip uninstall onnxruntime -y \
+#     && python -m pip install build/Linux/Release/dist/* \
+#     && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+#     && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
+#     && git clone https://github.com/huggingface/optimum-amd.git \
+#     && cd optimum-amd \
+#     && python -m pip install -e .; \
+# elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+## Interestingly the radeon onnxruntime-rocm works on mi300x and it has the same performance as
+## compiling the onnxruntime-rocm from source targeting mi300x build.
+## This zero performance gain could be related to this issue (https://github.com/huggingface/optimum-amd/issues/163)
+# OPTION2: Install onnxruntime-rocm from the wheel 
+RUN . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+&& python -m pip install /install/*.whl \
+&& git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+&& cd /tmp-optimum \
+&& python -m pip install .;
+# else \
+#     echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+#     exit 1; \
+# fi
 
 
 

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -66,6 +66,8 @@ RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
     && python -m pip uninstall onnxruntime -y \
     && python -m pip install build/Linux/Release/dist/* \
+    && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+    && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
     && git clone https://github.com/huggingface/optimum-amd.git \
     && cd optimum-amd \
     && python -m pip install -e .; \

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -47,44 +47,41 @@ COPY infinity_emb infinity_emb
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
-# ARG GPU_ARCH
-# ENV GPU_ARCH=${GPU_ARCH}
+ARG GPU_ARCH
+ENV GPU_ARCH=${GPU_ARCH}
 # GPU architecture specific installations
 RUN cd /opt/rocm/share/amd_smi \
 && python -m pip wheel . --wheel-dir=/install
 RUN apt update -y && apt install migraphx -y
-# RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
-#     # OPTION1: Follow the steps here to install onnxruntime-rocm 
-#     # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-#     . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
-#     && python -m pip install /install/*.whl \
-#     && python -m pip install cmake onnx \
-#     && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-#     && (. $HOME/.cargo/env) \
-#     && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-#     && cd onnxruntime \
-#     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
-#     && python -m pip uninstall onnxruntime -y \
-#     && python -m pip install build/Linux/Release/dist/* \
-#     && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
-#     && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
-#     && git clone https://github.com/huggingface/optimum-amd.git \
-#     && cd optimum-amd \
-#     && python -m pip install -e .; \
-# elif [ "$GPU_ARCH" = "gfx1100" ]; then \
-## Interestingly the radeon onnxruntime-rocm works on mi300x and it has the same performance as
-## compiling the onnxruntime-rocm from source targeting mi300x build.
-## This zero performance gain could be related to this issue (https://github.com/huggingface/optimum-amd/issues/163)
-# OPTION2: Install onnxruntime-rocm from the wheel 
-RUN . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
-&& python -m pip install /install/*.whl \
-&& git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
-&& cd /tmp-optimum \
-&& python -m pip install .;
-# else \
-#     echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
-#     exit 1; \
-# fi
+RUN if [ "$GPU_ARCH" = "gfx90a" ] || [ "$GPU_ARCH" = "gfx942" ]; then \
+    # OPTION1: Follow the steps here to install onnxruntime-rocm 
+    # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
+    . .venv/bin/activate && python -m pip uninstall onnxruntime -y \
+    && python -m pip install /install/*.whl \
+    && python -m pip install cmake onnx \
+    && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+    && (. $HOME/.cargo/env) \
+    && git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+    && cd onnxruntime \
+    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=${GPU_ARCH} ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --use_migraphx --rocm_home=/opt/rocm) \
+    && python -m pip uninstall onnxruntime -y \
+    && python -m pip install build/Linux/Release/dist/* \
+    && cp -r /app/onnxruntime/build/Linux/Release/*.so /usr/local/lib/ \
+    && cp -r /app/onnxruntime/build/Linux/Release/*.so.* /usr/local/lib/ \
+    && git clone https://github.com/huggingface/optimum-amd.git \
+    && cd optimum-amd \
+    && python -m pip install -e .; \
+elif [ "$GPU_ARCH" = "gfx1100" ]; then \
+    # OPTION2: Install onnxruntime-rocm from the wheel
+    . .venv/bin/activate && python -m pip uninstall onnxruntime onnxruntime-rocm -y && python -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl \
+    && python -m pip install /install/*.whl \
+    && git clone https://github.com/huggingface/optimum-amd.git /tmp-optimum \
+    && cd /tmp-optimum \
+    && python -m pip install .; \
+else \
+    echo "Unsupported GPU_ARCH: ${GPU_ARCH}"; \
+    exit 1; \
+fi
 
 
 

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -17,7 +17,7 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_VIRTUALENVS_IN_PROJECT="true" \
     # do not ask any interactive question
     POETRY_NO_INTERACTION=1 \
-    EXTRAS="all onnxruntime-gpu" \
+    EXTRAS="all" \
     PYTHON="python3.10"
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential python3-dev libsndfile1 $PYTHON-venv $PYTHON curl
 WORKDIR /app
@@ -47,24 +47,22 @@ COPY infinity_emb infinity_emb
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download.pytorch.org/whl/rocm6.2"
 
-# Follow the steps here to install onnxruntime-rocm 
+# OPTION1: Follow the steps here to install onnxruntime-rocm 
 # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
 RUN python3 -m pip uninstall onnxruntime \
-    && python3 -m pip install cmake onnx \
-    && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-    && (. $HOME/.cargo/env)
-
+  && python3 -m pip install cmake onnx \
+  && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+  && (. $HOME/.cargo/env)
 RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
     && cd onnxruntime \
     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
-    && python3 -m pip install build/Linux/Release/dist/* \
-    && cd ..
-
+    && python3 -m pip install build/Linux/Release/dist/* 
 RUN git clone https://github.com/huggingface/optimum-amd.git \
     && cd optimum-amd \
-    && pip install -e .
+    && pip install -e . 
+# OPTION2: Install onnxruntime-rocm from the wheel
+# RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
 
-#
 
 
 FROM builder as testing
@@ -73,15 +71,9 @@ FROM builder as testing
 COPY requirements_install_from_poetry.sh requirements_install_from_poetry.sh
 RUN ./requirements_install_from_poetry.sh  --with lint,test "https://download.pytorch.org/whl/rocm6.2"
 
-RUN /app/.venv/bin/python -m pip uninstall onnxruntime -y \
-    && /app/.venv/bin/python -m pip install onnxruntime/build/Linux/Release/dist/* \
-    && cd optimum-amd \
-    && /app/.venv/bin/python -m pip install -e .
-
 # lint 
-RUN poetry run ruff check . --exclude ./onnxruntime --exclude ./optimum-amd --exclude ./.venv
-RUN poetry run mypy . --exclude 'onnxruntime|optimum-amd|.venv'
-
+RUN poetry run ruff check .
+RUN poetry run mypy .
 # pytest
 COPY tests tests
 # run end to end tests because of duration of build in github ci.
@@ -109,12 +101,6 @@ RUN echo "all tests passed" > "test_results.txt"
 # Use a multi-stage build -> production version, with download
 FROM base AS tested-builder
 COPY --from=builder /app /app
-
-RUN /app/.venv/bin/python -m pip uninstall onnxruntime -y \
-    && /app/.venv/bin/python -m pip install onnxruntime/build/Linux/Release/dist/* \
-    && cd optimum-amd \
-    && /app/.venv/bin/python -m pip install -e .
-    
 # force testing stage to run
 COPY --from=testing /app/test_results.txt /app/test_results.txt
 ENV HF_HOME=/app/.cache/huggingface

--- a/libs/infinity_emb/Dockerfile.amd_auto
+++ b/libs/infinity_emb/Dockerfile.amd_auto
@@ -49,19 +49,22 @@ RUN ./requirements_install_from_poetry.sh  --without lint,test "https://download
 
 # OPTION1: Follow the steps here to install onnxruntime-rocm 
 # https://huggingface.co/docs/optimum/onnxruntime/usage_guides/amdgpu
-RUN python3 -m pip uninstall onnxruntime \
-  && python3 -m pip install cmake onnx \
-  && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
-  && (. $HOME/.cargo/env)
-RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
-    && cd onnxruntime \
-    && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
-    && python3 -m pip install build/Linux/Release/dist/* 
+# RUN python3 -m pip uninstall onnxruntime \
+#   && python3 -m pip install cmake onnx \
+#   && (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) \
+#   && (. $HOME/.cargo/env)
+# RUN git clone --single-branch --branch main --recursive https://github.com/Microsoft/onnxruntime onnxruntime \
+#     && cd onnxruntime \
+#     && (./build.sh --config Release --build_wheel --allow_running_as_root --update --build --parallel --cmake_extra_defines CMAKE_HIP_ARCHITECTURES=gfx90a,gfx942 ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm) \
+#     && python3 -m pip install build/Linux/Release/dist/* 
+# RUN git clone https://github.com/huggingface/optimum-amd.git \
+#     && cd optimum-amd \
+#     && pip install -e . 
+# OPTION2: Install onnxruntime-rocm from the wheel
+RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
 RUN git clone https://github.com/huggingface/optimum-amd.git \
     && cd optimum-amd \
     && pip install -e . 
-# OPTION2: Install onnxruntime-rocm from the wheel
-# RUN python3 -m pip uninstall onnxruntime onnxruntime-rocm && python3 -m pip install "numpy<2" https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2.3/onnxruntime_rocm-1.18.0-cp310-cp310-linux_x86_64.whl
 
 
 

--- a/libs/infinity_emb/Makefile
+++ b/libs/infinity_emb/Makefile
@@ -41,10 +41,10 @@ format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES)
 
 template_docker:
-	jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s amd > Dockerfile.amd_auto
-	jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s cpu > Dockerfile.cpu_auto
-	jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s nvidia > Dockerfile.nvidia_auto
-	jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s trt > Dockerfile.trt_onnx_auto
+	poetry run jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s amd > Dockerfile.amd_auto
+	poetry run jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s cpu > Dockerfile.cpu_auto
+	poetry run jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s nvidia > Dockerfile.nvidia_auto
+	poetry run jinja2 Dockerfile.jinja2 Docker.template.yaml --format=yaml -s trt > Dockerfile.trt_onnx_auto
 
 poetry_check:
 	poetry check

--- a/libs/infinity_emb/infinity_emb/_optional_imports.py
+++ b/libs/infinity_emb/infinity_emb/_optional_imports.py
@@ -64,6 +64,7 @@ CHECK_DISKCACHE = OptionalImports("diskcache", "cache")
 CHECK_FASTAPI = OptionalImports("fastapi", "server")
 CHECK_ONNXRUNTIME = OptionalImports("optimum.onnxruntime", "optimum")
 CHECK_OPTIMUM = OptionalImports("optimum", "optimum")
+CHECK_OPTIMUM_AMD = OptionalImports("optimum.amd", "optimum")
 CHECK_OPTIMUM_NEURON = OptionalImports(
     "optimum.neuron",
     "<neuronx not available as extra, only runs on AMI image, no pip install possible.>",

--- a/libs/infinity_emb/infinity_emb/primitives.py
+++ b/libs/infinity_emb/infinity_emb/primitives.py
@@ -107,6 +107,8 @@ class InferenceEngine(EnumType):
 class Device(EnumType):
     cpu = "cpu"
     cuda = "cuda"
+    rocm = "rocm"
+    migraphx = "migraphx"
     mps = "mps"
     tensorrt = "tensorrt"
     auto = "auto"

--- a/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
@@ -8,7 +8,7 @@ import numpy as np
 from huggingface_hub import HfApi, HfFolder  # type: ignore
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE  # type: ignore
 
-from infinity_emb._optional_imports import CHECK_ONNXRUNTIME, CHECK_TORCH
+from infinity_emb._optional_imports import CHECK_ONNXRUNTIME, CHECK_TORCH, CHECK_OPTIMUM_AMD
 from infinity_emb.log_handler import logger
 from infinity_emb.primitives import Device
 
@@ -52,9 +52,17 @@ def device_to_onnx(device: Device) -> str:
     if device == Device.cpu:
         return "CPUExecutionProvider"
     elif device == Device.cuda:
+        return "CUDAExecutionProvider"
+    elif device == Device.rocm:
         if torch.version.hip is not None:
             return "ROCMExecutionProvider"
-        return "CUDAExecutionProvider"
+        else:
+            raise ValueError("The `torch` installed is not for ROCm.")
+    elif device == Device.migraphx:
+        if torch.version.hip is not None:
+            return "MIGraphXExecutionProvider"
+        else:
+            raise ValueError("The `torch` installed is not for ROCm.")
     elif device == Device.mps:
         return "CoreMLExecutionProvider"
     elif device == Device.tensorrt:
@@ -89,12 +97,8 @@ def optimize_model(
         revision (Optional[str], optional): The revision to use. Defaults to None.
         trust_remote_code (bool, optional): Whether to trust the remote code. Defaults to True.
     """
-    CHECK_ONNXRUNTIME.mark_required()
-    path_folder = (
-        Path(HUGGINGFACE_HUB_CACHE) / "infinity_onnx" / execution_provider / model_name_or_path
-    )
-    OPTIMIZED_SUFFIX = "_optimized.onnx"
-    files_optimized = list(path_folder.glob(f"**/*{OPTIMIZED_SUFFIX}"))
+
+    ## If there is no need for optimization
     if execution_provider == "TensorrtExecutionProvider":
         return model_class.from_pretrained(
             model_name_or_path,
@@ -112,8 +116,28 @@ def optimize_model(
                 # "trt_int8_enable": "quantize" in file_name,
             },
         )
+
+    elif execution_provider in ["ROCMExecutionProvider", "MIGraphXExecutionProvider"]:
+        CHECK_OPTIMUM_AMD.mark_required()
+        return model_class.from_pretrained(
+            model_name_or_path,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+            provider=execution_provider,
+            file_name=file_name,
+        )
+
+    ## path to find if model has been optimized
+    CHECK_ONNXRUNTIME.mark_required()
+    path_folder = (
+        Path(HUGGINGFACE_HUB_CACHE) / "infinity_onnx" / execution_provider / model_name_or_path
+    )
+    OPTIMIZED_SUFFIX = "_optimized.onnx"
+    files_optimized = list(path_folder.glob(f"**/*{OPTIMIZED_SUFFIX}"))
+
+    logger.info(f"files_optimized: {files_optimized}")
     if files_optimized:
-        file_optimized = files_optimized[0]
+        file_optimized = files_optimized[-1]
         logger.info(f"Optimized model found at {file_optimized}, skipping optimization")
         return model_class.from_pretrained(
             file_optimized.parent.as_posix(),

--- a/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
@@ -52,6 +52,8 @@ def device_to_onnx(device: Device) -> str:
     if device == Device.cpu:
         return "CPUExecutionProvider"
     elif device == Device.cuda:
+        if torch.version.hip is not None:
+            return "ROCMExecutionProvider"
         return "CUDAExecutionProvider"
     elif device == Device.mps:
         return "CoreMLExecutionProvider"


### PR DESCRIPTION
# Description
Add `optimum-amd` support to `infinity_emb`.

**Note:** To use `optimum-amd`, it is recommended to 
1. build from docker image `docker build -f libs/infinity_emb/Dockerfile.amd_auto -t ghcr.io/embeddedllm/infinity-rocm:opti
mum-amd ./libs/infinity_emb`
2. Pull a docker image `docker pull ghcr.io/embeddedllm/infinity-rocm:optimum-amd` (This is a docker image of this PR. Hopefully in the newer version of infinity, the optimum-amd support can be found in https://hub.docker.com/r/michaelf34/infinity ) So for now, as a quickstart, get it from EmbeddedLLM.

To launch the docker container:
* Interactive mode:
  * Launch docker container
    ```bash
    #!/bin/bash
    
    docker run -it \
      --cap-add=SYS_PTRACE \
      --security-opt seccomp=unconfined \
      --device=/dev/kfd \
      --device=/dev/dri/renderD128 \
      --device=/dev/dri/renderD136 \
      --group-add video \
      --network host \
      --entrypoint /bin/bash \
      ghcr.io/embeddedllm/infinity-rocm:optimum-amd \
      -c "source .venv/bin/activate && bash"
      ```
   * Launch Embedding Model
      ```bash
      HIP_VISIBLE_DEVICES=0 infinity_emb v2 --port 6909 --model-id BAAI/bge-m3 --model-warmup --device cuda  --engine optimum 
      ```
* Single line:
```bash
  #!/bin/bash
  
  docker run -it \
    --cap-add=SYS_PTRACE \
    --security-opt seccomp=unconfined \
    --device=/dev/kfd \
    --device=/dev/dri/renderD128 \
    --device=/dev/dri/renderD136 \
    --group-add video \
    --network host \
    --entrypoint /bin/bash \
    ghcr.io/embeddedllm/infinity-rocm:optimum-amd \
    -c "(source .venv/bin/activate) && (HIP_VISIBLE_DEVICES=0 infinity_emb v2 --port 6909 --model-id BAAI/bge-m3 --model-warmup --device cuda  --engine optimum)"
```


# CHANGES
* `libs/infinity_emb/Dockerfile.amd_auto`
  * Added installation step of `onnxruntime-rocm` and `optimum-amd`.


# Performance
These are the steps obtained in the warm-up run of the infinity server

| Configuration |  Performance |
|-----------------|----------------|
| Torch only | `model warmed up, between 476.69-2408.85 embeddings/sec at batch_size=32` |
| Torch Compile | `model warmed up, between 487.85-2789.83 embeddings/sec at batch_size=32` |
| Optimum AMD | `model warmed up, between 268.33-4903.16 embeddings/sec at batch_size=32` |

Running `benchmark_embed`
| Model                                       | Requests # / sec (mean) | Time (seconds) |
|---------------------------------------------|-------------------------|----------------|
| infinity (torch + no compile + fa2 disabled)| 2.52                    | 3.965         |
| infinity (torch +  compile + fa2 disabled)  | 0.52 (first run), 2.84 (second run)    | 18.612   , 3.517      |
| infinity (optimum-amd)  |  1.33    | 7.523      |

## Torch Only
![torch-only](https://github.com/user-attachments/assets/bae8a4ba-faf6-4425-a90b-a757c84b633d)

## Torch Compile
![torch-compile](https://github.com/user-attachments/assets/d8883ca3-b0a5-4e12-a8fc-d5bc562db237)

## Optimum-AMD
![Screenshot 2024-10-26 220350](https://github.com/user-attachments/assets/b3da1669-5045-450c-8cd5-c726cd7ea508)
![Screenshot 2024-10-26 220308](https://github.com/user-attachments/assets/28c47e6b-7289-4fb7-9801-833ad7cadf5f)
![Screenshot 2024-10-26 220442](https://github.com/user-attachments/assets/f3173f8f-b478-48f4-bf0e-404d6ed10469)

