### PR TITLE
Fixed Broken License Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ All contributions must be made in a way to be compatible with the MIT License of
 [issues-shield]: https://img.shields.io/github/issues/michaelfeil/infinity.svg?style=for-the-badge
 [issues-url]: https://github.com/michaelfeil/infinity/issues
 [license-shield]: https://img.shields.io/github/license/michaelfeil/infinity.svg?style=for-the-badge
-[license-url]: https://github.com/michaelfeil/infinity/blob/master/LICENSE.txt
+[license-url]: https://github.com/michaelfeil/infinity/blob/main/LICENSE
 [pepa-shield]: https://static.pepy.tech/badge/infinity-emb
 [pepa-url]: https://www.pepy.tech/projects/infinity-emb
 [codecov-shield]: https://codecov.io/gh/michaelfeil/infinity/branch/main/graph/badge.svg?token=NMVQY5QOFQ


### PR DESCRIPTION
## Description
The MIT license was broken in the README file. Now updated to correct link.

## Related Issue
Solves #445 

## Types of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/michaelfeil/infinity/tree/main?tab=readme-ov-file#contribute-and-develop) guidelines.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have updated the documentation accordingly.

## Additional Notes
Add any other context about the PR here.

## License
By submitting this PR, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/michaelfeil/infinity/blob/main/LICENSE).
