### PR TITLE
Fix : modernbert implementation is not compatible with FX

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/embedder/sentence_transformer.py
+++ b/libs/infinity_emb/infinity_emb/transformer/embedder/sentence_transformer.py
@@ -67,8 +67,8 @@ class SentenceTransformerPatched(SentenceTransformer, BaseEmbedder):
             revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
         )
+        config_kwargs = {}
         if config.model_type == 'modernbert':
-            config_kwargs={}
             config_kwargs["reference_compile"] = False
         
 


### PR DESCRIPTION
According to https://huggingface.co/answerdotai/ModernBERT-base/discussions/14#67695db4f711d4eac4a43ddf, we need to explicitly pass 'reference_compile=False' to model to avoid trigger 'RuntimeError: Detected that you are using FX to symbolically trace a dynamo-optimized function. This is not supported at the moment'