### PR TITLE
Caching huggingface models in GH actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,27 +31,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest] # macos-latest
         python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
           - "3.12"
         coverage_tests: ["unit_test", "end_to_end"]
-        exclude:
-          # Exclude unit tests on macOS due to compatibility issues
-          - python-version: "3.9"
-            os: macos-latest
-            coverage_tests: "unit_test"
-          - python-version: "3.10"
-            os: macos-latest
-            coverage_tests: "unit_test"
-          - python-version: "3.11"
-            os: macos-latest
-            coverage_tests: "unit_test"
-          - python-version: "3.12"
-            os: macos-latest
-            coverage_tests: "unit_test"
-        # continue-on-error: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
-
           
     runs-on: ${{ matrix.os }}
     name: Py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.coverage_tests }}
@@ -82,6 +63,14 @@ jobs:
         shell: bash
         run: poetry install ${{ inputs.extra_poetry }}
 
+      - name: Restore cached HuggingFace models
+        id: cache-models-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/huggingface/hub
+          key: hf-models
+
       - name: Run Pytest Coverage
         if: ${{ inputs.working-directory == 'libs/infinity_emb' }}
         run: |
@@ -98,3 +87,14 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+      - name: Save HuggingFace models
+        id: cache-models-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/huggingface/hub
+          key: hf-models
+
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,76 @@ env:
 
 
 jobs:
-  testing-job:
+  initial-job: # Run initial job to create model cache
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest] # macos-latest
+        python-version:
+          - "3.12"
+        coverage_tests: ["unit_test", "end_to_end"]
+          
+    runs-on: ${{ matrix.os }}
+    name: Py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.coverage_tests }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Free Disk Space
+        uses: "./.github/actions/disk_cleanup"
+        if: runner.os == 'Linux'
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+      - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}
+        uses: "./.github/actions/poetry_setup"
+        with:
+          python-version: ${{ matrix.python-version }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          working-directory: ${{ inputs.working-directory }}
+          cache-key: ${{ inputs.working-directory }}-test-${{ matrix.coverage_tests }}
+
+      - name: Install dependencies from local
+        # only if source is local
+        shell: bash
+        run: poetry install ${{ inputs.extra_poetry }}
+
+      - name: Cache HuggingFace models
+        id: cache-models
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface/hub
+          key: hf-models-${{ inputs.working-directory }}-test-${{ matrix.coverage_tests }}
+
+
+      - name: Run Pytest Coverage
+        if: ${{ inputs.working-directory == 'libs/infinity_emb' }}
+        run: |
+          poetry run coverage run -m --source ./infinity_emb pytest tests/${{ matrix.coverage_tests }} 
+          poetry run coverage xml
+      
+      - name: Run Pytest Coverage w/o infinity
+        if: ${{ inputs.working-directory != 'libs/infinity_emb' }}
+        run: 
+          make coverage
+
+      - name: Upload coverage Report to Codecov for python 3.11
+        if: ${{ matrix.python-version == '3.11' && inputs.upload_coverage == true && matrix.os == 'ubuntu-latest'}}
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+  testing-job: # Run the other jobs to use cache from initial job
+    needs: initial-job
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -34,7 +103,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
         coverage_tests: ["unit_test", "end_to_end"]
           
     runs-on: ${{ matrix.os }}
@@ -72,9 +140,7 @@ jobs:
         with:
           path: |
             ~/.cache/huggingface/hub
-          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}-${{ github.workspace }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}-${{ github.workspace }}
+          key: hf-models-${{ inputs.working-directory }}-test-${{ matrix.coverage_tests }}
 
       - name: Run Pytest Coverage
         if: ${{ inputs.working-directory == 'libs/infinity_emb' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ env:
 
 
 jobs:
+  base-job:
   testing-job:
     defaults:
       run:
@@ -69,7 +70,7 @@ jobs:
         with:
           path: |
             ~/.cache/huggingface/hub
-          key: hf-models
+          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}
 
       - name: Run Pytest Coverage
         if: ${{ inputs.working-directory == 'libs/infinity_emb' }}
@@ -95,6 +96,6 @@ jobs:
         with:
           path: |
             ~/.cache/huggingface/hub
-          key: hf-models
+          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest] # macos-latest
         python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
           - "3.12"
         coverage_tests: ["unit_test", "end_to_end"]
           
@@ -63,13 +66,15 @@ jobs:
         shell: bash
         run: poetry install ${{ inputs.extra_poetry }}
 
-      - name: Restore cached HuggingFace models
-        id: cache-models-restore
-        uses: actions/cache/restore@v4
+      - name: Cached HuggingFace models
+        id: cache-models
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/huggingface/hub
-          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}
+          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}-${{ github.workspace }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}-${{ github.workspace }}
 
       - name: Run Pytest Coverage
         if: ${{ inputs.working-directory == 'libs/infinity_emb' }}
@@ -87,14 +92,5 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-
-      - name: Save HuggingFace models
-        id: cache-models-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-          key: hf-models-${{ matrix.os }}-${{ matrix.coverage_tests }}
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,6 @@ env:
 
 
 jobs:
-  base-job:
   testing-job:
     defaults:
       run:


### PR DESCRIPTION
Attempt to reduce traffic to huggingface to get rid of errors like: 
```
 huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/models/mixedbread-ai/mxbai-rerank-xsmall-v1/tree/main?recursive=True&expand=False
```

Attempt is to cache the hf models to avoid redownload every run.


This adds some support for caching huggingface models for the CI pipeline:

   -  Run the tests for python3.12 and cache the HF_HOME/hub folder during this run for each of the tests
   - After that, run the tests for python 3.9 - 3.11 and use the cache which was created in the step above

This should reduce the required download of the models.