### PR TITLE
Fix client generation pipeline

### DIFF
--- a/libs/client_infinity/run_generate_with_hook.sh
+++ b/libs/client_infinity/run_generate_with_hook.sh
@@ -34,7 +34,7 @@ python -m pip install openapi-python-client==0.21.1 && \
 	 openapi-python-client generate  \
 	  --url http://0.0.0.0:7993/openapi.json \
 	  --config client_config.yaml \
-    --meta poetry \
+	  --meta poetry \
 	  --overwrite \
 	  --custom-template-path=./template
 

--- a/libs/client_infinity/run_generate_with_hook.sh
+++ b/libs/client_infinity/run_generate_with_hook.sh
@@ -34,8 +34,9 @@ python -m pip install openapi-python-client==0.21.1 && \
 	 openapi-python-client generate  \
 	  --url http://0.0.0.0:7993/openapi.json \
 	  --config client_config.yaml \
-	   --overwrite \
-	   --custom-template-path=./template
+    --meta poetry \
+	  --overwrite \
+	  --custom-template-path=./template
 
 # copy the readme to docs
 cp ./template/vision_client.py ./infinity_client/infinity_client/vision_client.py


### PR DESCRIPTION
Fix client generation pipeline as seen in [this](https://github.com/michaelfeil/infinity/actions/runs/15797325241/job/44531045589) run by explicitly setting meta type to poetry

```bash
Usage: openapi-python-client generate [OPTIONS]
Try 'openapi-python-client generate --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid value for '--meta' (env var: 'None'): <MetaType.POETRY: 'poetry'> is │
│ not one of 'none', 'poetry', 'setup', 'pdm'.                                 │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Seems to be some enum/str  problem. 