### PR TITLE
Stop future if exception occurs to avoid blocking following requests

### DIFF
--- a/libs/infinity_emb/infinity_emb/inference/batch_handler.py
+++ b/libs/infinity_emb/infinity_emb/inference/batch_handler.py
@@ -445,7 +445,7 @@ class BatchHandler:
                 results, batch = post_batch
 
                 for i, item in enumerate(batch):
-                    if isinstance(results,Exception):
+                    if isinstance(results, Exception):
                         await item.set_exception(results)
                     else:
                         await item.complete(results[i])

--- a/libs/infinity_emb/infinity_emb/infinity_server.py
+++ b/libs/infinity_emb/infinity_emb/infinity_server.py
@@ -389,7 +389,7 @@ def create_server(
             )
         except Exception as ex:
             raise errors.OpenAIException(
-                f"InternalServerError: {ex}",
+                f"InternalServerError: {type(ex).__name__} {ex}",
                 code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/libs/infinity_emb/infinity_emb/primitives.py
+++ b/libs/infinity_emb/infinity_emb/primitives.py
@@ -280,6 +280,18 @@ class AbstractInner(ABC, Generic[AbstractInnerType]):
     async def get_result(self) -> AbstractInnerType:
         pass
 
+    async def set_exception(self, exception: Exception) -> None:
+        """marks the future for completion.
+        only call from the same thread as created future."""
+        self.exception = exception
+
+        if self.exception is None:
+            raise ValueError("exception is None")
+        try:
+            self.future.set_exception(self.exception)
+        except asyncio.exceptions.InvalidStateError:
+            pass
+
 
 @dataclass(order=True, **dataclass_args)
 class EmbeddingInner(AbstractInner):
@@ -345,6 +357,7 @@ class PredictInner(AbstractInner):
             self.future.set_result(self.class_encoding)
         except asyncio.exceptions.InvalidStateError:
             pass
+
 
     async def get_result(self) -> ClassifyReturnType:
         """waits for future to complete and returns result"""

--- a/libs/infinity_emb/infinity_emb/primitives.py
+++ b/libs/infinity_emb/infinity_emb/primitives.py
@@ -358,7 +358,6 @@ class PredictInner(AbstractInner):
         except asyncio.exceptions.InvalidStateError:
             pass
 
-
     async def get_result(self) -> ClassifyReturnType:
         """waits for future to complete and returns result"""
         await self.future


### PR DESCRIPTION
When an exception occurs within the `batch_handler`, pass the exception in the result queue and let the future raise the exception so it can be reported to the client.

See #609 

Before request with e.g. corrupted image got "stuck" , after:
```bash
curl -vv http://localhost:7997/embeddings   --http1.1 -H "Authorization: Bearer doesnt-matter"   -H "Content-Type: application/json"   -d '{ 
    "input": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9sXsdrgAAAAASUVORK5CYII=",
    "model": "repro", 
    "modality": "image"
  }'
* Host localhost:7997 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:7997...
* connect to ::1 port 7997 from ::1 port 53458 failed: Connection refused
*   Trying 127.0.0.1:7997...
* Connected to localhost (127.0.0.1) port 7997
> POST /embeddings HTTP/1.1
> Host: localhost:7997
> User-Agent: curl/8.9.1
> Accept: */*
> Authorization: Bearer doesnt-matter
> Content-Type: application/json
> Content-Length: 184
> 
* upload completely sent off: 184 bytes
< HTTP/1.1 500 Internal Server Error
< date: Wed, 02 Jul 2025 16:39:37 GMT
< server: uvicorn
< content-length: 131
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"error":{"message":"InternalServerError: OSError broken data stream when reading image file","type":null,"param":null,"code":500}}
```
