### PR TITLE
fixed super.init in SentenceTransformerPatched

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/embedder/sentence_transformer.py
+++ b/libs/infinity_emb/infinity_emb/transformer/embedder/sentence_transformer.py
@@ -69,13 +69,14 @@ class SentenceTransformerPatched(SentenceTransformer, BaseEmbedder):
         if ls.loading_dtype is not None:
             model_kwargs["torch_dtype"] = ls.loading_dtype
 
-        super().__init__(
-            engine_args.model_name_or_path,
+        temp_model = SentenceTransformer(**dict(
+            model_name_or_path=engine_args.model_name_or_path,
             revision=engine_args.revision,
             trust_remote_code=engine_args.trust_remote_code,
             device=ls.device_placement,
             model_kwargs=model_kwargs,
-        )
+        ))
+        self.__dict__.update(temp_model.__dict__)
         self.to(ls.device_placement)
         # make a copy of the tokenizer,
         # to be able to could the tokens in another thread


### PR DESCRIPTION
<!--
Congratulations! You've made it this far! Thanks for submitting a PR to Infinity!

## License & CLA
By submitting this PR, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/michaelfeil/infinity/blob/main/LICENSE).
-->

## Related Issue

The problem stems from the `__init__` method of the parent class, `SentenceTransformer`. This method uses `self.__class__.__name__` to [set a configuration value](https://github.com/UKPLab/sentence-transformers/blob/d5c8f5181daa468c63041fde18c659c4e4267e77/sentence_transformers/SentenceTransformer.py#L200).

When subclass `SentenceTransformerPatched` calls `super().__init__()`, `self.__class__.__name__` evaluates to `"SentenceTransformerPatched"`. The parent class's internal logic is not designed for this and expects the name to be `"SentenceTransformer"`, which leads to incorrect config and problems like this:

> WARNING: No sentence-transformers model found with name temp/models/model_1752105604572. Creating a new one with mean pooling.


The fix avoids calling `super().__init__()` directly. Instead, it creates a temporary instance of the base `SentenceTransformer` class, which initializes correctly. It then copies the state from this temporary object to the current instance (`self`), effectively bypassing the problematic check while still properly initializing the object.

<!--
If you are sure that a related issue should be automatically closed, use the syntax to close issue 123.

closes #123
-->

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/michaelfeil/infinity/tree/main?tab=readme-ov-file#contribute-and-develop) guidelines.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (docs folder) accordingly.

## Additional Notes
I tried to run the poetry tests but got stuck here:
```
Installing dependencies from lock file

Finding the necessary packages for the current system

Package operations: 167 installs, 1 update, 0 removals, 3 skipped

  - Installing certifi (2024.8.30): Pending...
Checking if keyring is available
  - Installing charset-normalizer (3.4.0): Pending...
  - Installing frozenlist (1.4.1): Pending...
  - Installing idna (3.10): Pending...
  - Installing multidict (6.1.0): Pending...
  - Installing nvidia-nvjitlink-cu12 (12.4.127): Pending...
  - Installing propcache (0.2.0): Pending...
  - Installing urllib3 (2.2.3): Pending...
[keyring:keyring.backend] Loading KWallet
[keyring:keyring.backend] Loading SecretService
[keyring:keyring.backend] Loading Windows
[keyring:keyring.backend] Loading chainer
[keyring:keyring.backend] Loading libsecret
[keyring:keyring.backend] Loading macOS
Using keyring backend 'SecretService Keyring'
```
