### PR TITLE
torch_vision.py: use set device type

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/vision/torch_vision.py
+++ b/libs/infinity_emb/infinity_emb/transformer/vision/torch_vision.py
@@ -106,7 +106,7 @@ class TIMM(BaseTIMM):
             assert hasattr(
                 self.model, "get_image_features"
             ), f"AutoModel of {engine_args.model_name_or_path} does not have get_image_features method"
-        if torch.cuda.is_available():
+        if device==Device.cuda:
             self.model = self.model.cuda()
             if engine_args.dtype in (Dtype.float16, Dtype.auto):
                 self.model = self.model.half()


### PR DESCRIPTION
Currently, if cuda is available cuda is used. With this change, device settings are used. 

Related Issue: https://github.com/michaelfeil/infinity/issues/569



