### PR TITLE
Use `get_token` instead of deprecated `HFFolder.get_token`

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/utils_optimum.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
-from huggingface_hub import HfApi, HfFolder  # type: ignore
+from huggingface_hub import HfApi, get_token  # type: ignore
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE  # type: ignore
 
 from infinity_emb._optional_imports import CHECK_ONNXRUNTIME, CHECK_OPTIMUM_AMD
@@ -209,7 +209,7 @@ def _list_all_repo_files(
 ):
     if not Path(model_name_or_path).exists():
         if isinstance(use_auth_token, bool):
-            token = HfFolder().get_token()
+            token = get_token()
         else:
             token = use_auth_token
         return list(


### PR DESCRIPTION
~~Only merge after updating `huggingface_hub > 1`~~

 `get token` is already available in `0.34.1`. See [here](https://github.com/huggingface/huggingface_hub/blob/84a92a92c24b7755963ab4195bf2c8b4129c911f/src/huggingface_hub/__init__.py#L871)

Tested locally:
```python
poetry run python3 -c "import huggingface_hub;from huggingface_hub import get_token;print(huggingface_hub.__version__)"
0.34.4
```

Should address #653 