### PR TITLE
fix(classify): honor raw_scores flag (return logits, softmax only when raw_scores=False)

### DIFF
--- a/libs/infinity_emb/infinity_emb/inference/batch_handler.py
+++ b/libs/infinity_emb/infinity_emb/inference/batch_handler.py
@@ -244,9 +244,14 @@ class BatchHandler:
         items = [PredictSingle(sentence=s) for s in sentences]
         classifications, usage = await self._schedule(items)
 
-        if raw_scores:
-            # perform softmax on scores
-            pass
+        if not raw_scores:
+            # the model returns raw logits; convert them to probabilities
+            for prediction in classifications:
+                logits = np.array([label["score"] for label in prediction])
+                exp = np.exp(logits - logits.max())
+                probs = exp / exp.sum()
+                for label, prob in zip(prediction, probs):
+                    label["score"] = float(prob)
 
         return classifications, usage
 

--- a/libs/infinity_emb/infinity_emb/transformer/classifier/optimum.py
+++ b/libs/infinity_emb/infinity_emb/transformer/classifier/optimum.py
@@ -70,7 +70,7 @@ class OptimumClassifier(BaseClassifer):
         return sentences
 
     def encode_core(self, sentences: list[str]) -> dict:
-        outputs = self._pipe(sentences)
+        outputs = self._pipe(sentences, function_to_apply="none")
         return outputs
 
     def encode_post(self, classes) -> dict[str, float]:

--- a/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
+++ b/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
@@ -73,7 +73,13 @@ class SentenceClassifier(BaseClassifer):
 
     def encode_core(self, features):
         """runs plain inference, on cpu/gpu"""
-        return self._pipe(features, batch_size=256, truncation=True, padding=True)
+        return self._pipe(
+            features,
+            batch_size=256,
+            truncation=True,
+            padding=True,
+            function_to_apply="none",
+        )
 
     def encode_post(self, classes) -> dict[str, float]:
         """runs post encoding such as normalization"""


### PR DESCRIPTION
### Problem

`/classify` ignores the `raw_scores` parameter — softmax probabilities are always returned (#658).

The classifiers run an HF `text-classification` `pipeline(..., top_k=None)`, which applies softmax internally by default. The handler's post-processing block was a no-op:

```python
if raw_scores:
    # perform softmax on scores
    pass
```

So the flag never had any effect, and raw logits were never reachable.

### Fix

Mirror the existing `rerank` path (model returns raw scores, activation applied conditionally in the handler):

- `SentenceClassifier` / `OptimumClassifier`: call the pipeline with `function_to_apply="none"` so it emits **raw logits**.
- `BatchHandler.classify`: apply a numerically-stable softmax only when `raw_scores` is `False`.

`raw_scores=True` now returns logits; the default `raw_scores=False` path is unchanged (softmax is monotonic, so the descending order the pipeline produces is preserved, and the resulting probabilities are identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
