### PR TITLE
fix(deps): bump typer to >=0.20.0 so the CLI works with click >=8.3 (#650)

### DIFF
--- a/libs/infinity_emb/poetry.lock
+++ b/libs/infinity_emb/poetry.lock
@@ -169,6 +169,17 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -4363,20 +4374,20 @@ tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.23.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
-    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+    {file = "typer-0.23.2-py3-none-any.whl", hash = "sha256:e9c8dc380f82450b3c851a9b9d5a0edf95d1d6456ae70c517d8b06a50c7a9978"},
+    {file = "typer-0.23.2.tar.gz", hash = "sha256:a99706a08e54f1aef8bb6a8611503808188a4092808e86addff1828a208af0de"},
 ]
 
 [package.dependencies]
-click = ">=8.0.0"
-rich = ">=10.11.0"
+annotated-doc = ">=0.0.2"
+click = {version = ">=8.0.0", markers = "python_version < \"3.10\""}
+rich = ">=12.3.0"
 shellingham = ">=1.3.0"
-typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "types-cffi"
@@ -5128,4 +5139,4 @@ vision = ["colpali-engine", "pillow", "timm", "torchvision"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "333b762ddf02aa6e7ed605304577cd4d4f34ad031275b27f79b0a7d8641cf1f9"
+content-hash = "a4b7c43ed0e814f18421f822f8f0e2552e12e84043b755a9e01bba3a011d8c81"

--- a/libs/infinity_emb/pyproject.toml
+++ b/libs/infinity_emb/pyproject.toml
@@ -23,7 +23,7 @@ fastapi = {version = ">=0.103.2", optional=true}
 orjson = {version = ">=3.9.8,!=3.10.0", optional=true} 
 prometheus-fastapi-instrumentator = {version = ">=6.1.0", optional=true}
 uvicorn = {version = "^0.32.0", optional=true, extras = ["standard"]}
-typer = {version = "^0.12.5", optional=true}
+typer = {version = ">=0.20.0", optional=true}
 pydantic = {version = ">=2.4.0,<3", optional=true} 
 posthog = {version = "*", optional=true}
 # backend


### PR DESCRIPTION
## Problem

Running the CLI (`infinity_emb v2 ...`) crashes at startup when `click >= 8.2/8.3` is installed:

```
TypeError: Secondary flag is not valid for non-boolean flag.
```

(Reported in #650; `#649` users hit it after `pip install infinity[all]` pulls a recent click.)

### Root cause

Several CLI options in `libs/infinity_emb/infinity_emb/cli.py` are declared as `list[bool]`, e.g.:

```python
trust_remote_code: list[bool] = typer.Option(...)
model_warmup:      list[bool] = typer.Option(...)
compile:           list[bool] = typer.Option(...)
onnx_disable_optimize: list[bool] = typer.Option(...)
# ... and more
```

typer 0.12.x auto-generates a secondary `--no-<flag>` for each `bool`, but for a **multiple** (`list[...]`) option click 8.2+ now rejects a secondary flag, raising the error above. typer's click-param generation was fixed in later releases — as confirmed in #650, bumping typer makes the error disappear (typer `0.12.5` + click `8.3.0` crashes; recent typer does not).

## Fix

The `^0.12.5` constraint pinned typer to the broken `0.12.x` line. This bumps the lower bound to `>=0.20.0` (the version confirmed working in #650 by @wirthual); `poetry lock --no-update` resolves typer `0.23.2`, which emits click-8.3-compatible params. The `poetry.lock` change is minimal — only the typer entry, its new transitive dep `annotated-doc`, and the content hash.

`poetry check --lock` passes.

If you've verified an even lower typer release works, feel free to relax the bound — I used `>=0.20.0` because that's the value explicitly confirmed in the thread.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
