### PR TITLE
fix(cache): a failed disk-cache write no longer kills the writer thread

### DIFF
--- a/libs/infinity_emb/infinity_emb/inference/caching_layer.py
+++ b/libs/infinity_emb/infinity_emb/inference/caching_layer.py
@@ -58,11 +58,19 @@ class Cache:
                 item = self._add_q.get(timeout=0.5)
             except queue.Empty:
                 continue
-            if item is not None:
-                k, v = item
-                self._cache.add(key=self._pre_hash(k), value=v, expire=86400)
-            self._add_q.task_done()
-        self._threadpool.shutdown(wait=True)
+            try:
+                if item is not None:
+                    k, v = item
+                    self._cache.add(key=self._pre_hash(k), value=v, expire=86400)
+            except Exception as ex:
+                # a best-effort cache must never take down its own writer thread.
+                logger.warning(f"failed to write to the vector disk cache: {ex}")
+            finally:
+                self._add_q.task_done()
+        # this runs *on* a worker of self._threadpool, so wait=True would join the
+        # current thread and raise `RuntimeError: cannot join current thread` into a
+        # Future that is never retrieved.
+        self._threadpool.shutdown(wait=False)
 
     def _get(self, sentence: str) -> Union[None, EmbeddingReturnType, list[float]]:
         """sets the item.complete() and sets embedding, if in cache."""

--- a/libs/infinity_emb/tests/unit_test/inference/test_caching_layer.py
+++ b/libs/infinity_emb/tests/unit_test/inference/test_caching_layer.py
@@ -42,3 +42,39 @@ async def test_cache():
     finally:
         INFINITY_CACHE_VECTORS = False
         shutdown.set()
+
+
+@pytest.mark.anyio
+async def test_consumer_survives_failed_write(monkeypatch):
+    """a raising `_cache.add` must not kill the only queue consumer.
+
+    Before the fix, the exception escaped `_consume_queue`, ended the single writer
+    thread, and was swallowed by the never-retrieved Future from `_threadpool.submit`.
+    `_add_q` then had no consumer at all and grew for the lifetime of the process.
+    """
+    shutdown = threading.Event()
+    try:
+        c = caching_layer.Cache(cache_name="pytest_write_error", shutdown=shutdown)
+        seen: list[str] = []
+        real_add = c._cache.add
+
+        def flaky(**kwargs):
+            seen.append(kwargs["key"])
+            if kwargs["key"] == "boom":
+                raise RuntimeError("simulated disk failure")
+            return real_add(**kwargs)
+
+        monkeypatch.setattr(c._cache, "add", flaky)
+        c._add_q.put(("boom", [1.0]))
+        c._add_q.put(("fine", [2.0]))
+
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            if seen == ["boom", "fine"]:
+                break
+
+        # the writer processed the item *after* the one that raised
+        assert seen == ["boom", "fine"]
+        assert c._get("fine") == [2.0]
+    finally:
+        shutdown.set()


### PR DESCRIPTION
### What

`Cache._consume_queue` runs the only consumer of `self._add_q`. The `self._cache.add(...)`
call inside it is unguarded, so any exception raised by diskcache propagates out of
`_consume_queue` and terminates that thread. Because the thread was started with
`self._threadpool.submit(self._consume_queue)` and the resulting `Future` is never
retrieved, the exception is swallowed silently — nothing is logged.

From that moment on `_add_q` has no consumer at all. It is unbounded, and
`aget_complete` keeps putting `(sentence, embedding)` pairs into it for every cache
miss, so it grows for the lifetime of the process while the cache stores nothing.
There is no external symptom until memory runs out.

A best-effort vector cache should never be able to take down its own writer.

### Also in this PR

`self._threadpool.shutdown(wait=True)` on the last line of `_consume_queue` executes
*on a worker of that same pool*, so it calls `Thread.join()` on the current thread and
raises `RuntimeError: cannot join current thread` — also swallowed by the unretrieved
Future. Since `ThreadPoolExecutor._threads` is a set with arbitrary iteration order,
the other workers may or may not be joined first, so the `wait=True` contract is not
honoured either way. Changed to `wait=False` with a comment explaining why.

Committed as two separate commits so the shutdown change can be dropped independently
if you would rather handle it another way.

### Test

Added `test_consumer_survives_failed_write` to the existing
`tests/unit_test/inference/test_caching_layer.py`. It monkeypatches `_cache.add` to
raise on the first item, then asserts the second item is still written — which fails
on `main` and passes here. It polls rather than sleeping a fixed interval, since
`windows-latest` is in the CI matrix.

### Deliberately not in scope

No `maxsize` on `_add_q`, no new env var, no `Cache.close()` wired into
`BatchHandler.shutdown()`. Under normal operation the producer only enqueues *after* a
completed forward pass, and one SQLite `add()` is orders of magnitude cheaper than an
inference, so the queue cannot outrun the writer while the writer is alive. Bounding it
would be treating the symptom. Happy to add any of those separately if you want them.

### Verified locally

Windows, Python 3.11.9, `poetry install -E cache -E torch -E server --with test,lint,codespell`:

```
$ poetry run pytest tests/unit_test/inference/test_caching_layer.py -v
tests/unit_test/inference/test_caching_layer.py::test_cache PASSED                        [ 50%]
tests/unit_test/inference/test_caching_layer.py::test_consumer_survives_failed_write PASSED [100%]
2 passed in 1.93s
```

The same new test, run against unmodified `main` (fix reverted, test kept), fails as it should:

```
FAILED tests/unit_test/inference/test_caching_layer.py::test_consumer_survives_failed_write
1 failed in 8.04s
```

`ruff check` and `codespell` pass; `ruff format --check` does not flag either changed file;
`mypy ./infinity_emb` produces output identical to `main` (4 pre-existing `import-not-found`
notes for `uvloop` / `optimum`, from installing without those extras).
