### PR TITLE
fix(classifier): adopt the tokenizer pad_token_id when the model config lacks one

### DIFF
--- a/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
+++ b/libs/infinity_emb/infinity_emb/transformer/classifier/torch.py
@@ -18,6 +18,24 @@ if CHECK_TORCH.is_available:
     import torch
 
 
+def _set_pad_token_id_if_missing(model, tokenizer) -> None:
+    """Copy the tokenizer's pad_token_id onto the model config when it is missing.
+
+    Decoder-only sequence-classification heads (e.g. Qwen2/Qwen3ForSequenceClassification)
+    raise `Cannot handle batch sizes > 1 if no padding token is defined.` when
+    `config.pad_token_id` is unset, and several published checkpoints ship without it.
+    """
+    if getattr(model.config, "pad_token_id", None) is not None:
+        return
+    pad_token_id = getattr(tokenizer, "pad_token_id", None)
+    if pad_token_id is None:
+        return
+    logger.info(
+        f"model config has no pad_token_id, adopting the tokenizer's pad_token_id={pad_token_id}"
+    )
+    model.config.pad_token_id = pad_token_id
+
+
 class SentenceClassifier(BaseClassifer):
     def __init__(
         self,
@@ -44,6 +62,8 @@ class SentenceClassifier(BaseClassifer):
             revision=engine_args.revision,
             model_kwargs=model_kwargs,
         )
+
+        _set_pad_token_id_if_missing(self._pipe.model, self._pipe.tokenizer)
 
         if ls.quantization_dtype is not None:
             self._pipe.model = quant_interface(  # TODO: add ls.quantization_dtype and ls.placement

--- a/libs/infinity_emb/tests/unit_test/transformer/classifier/test_torch_classifer.py
+++ b/libs/infinity_emb/tests/unit_test/transformer/classifier/test_torch_classifer.py
@@ -1,8 +1,13 @@
+from types import SimpleNamespace
+
 import torch
 from transformers import pipeline  # type: ignore
 
 from infinity_emb.args import EngineArgs
-from infinity_emb.transformer.classifier.torch import SentenceClassifier
+from infinity_emb.transformer.classifier.torch import (
+    SentenceClassifier,
+    _set_pad_token_id_if_missing,
+)
 
 
 def test_classifier(model_name: str = "SamLowe/roberta-base-go_emotions"):
@@ -40,3 +45,37 @@ def test_classifier(model_name: str = "SamLowe/roberta-base-go_emotions"):
 
             if pred_orig_i["score"] > 0.005:
                 assert pred_orig_i["label"] == pred_i["label"]
+
+
+def test_set_pad_token_id_if_missing_adopts_tokenizer_value():
+    """decoder-only seq-cls checkpoints often ship without config.pad_token_id.
+
+    transformers then raises `Cannot handle batch sizes > 1 if no padding token is
+    defined.`, which infinity hits during warmup (batch_size 32) before serving a
+    single request. michaelfeil/Qwen3-Reranker-0.6B-seq is such a checkpoint.
+    """
+    model = SimpleNamespace(config=SimpleNamespace(pad_token_id=None))
+    tokenizer = SimpleNamespace(pad_token_id=151643)
+
+    _set_pad_token_id_if_missing(model, tokenizer)
+
+    assert model.config.pad_token_id == 151643
+
+
+def test_set_pad_token_id_if_missing_is_noop_when_already_set():
+    """strict no-op for every model that works today (BERT rerankers, mxbai-*-seq)."""
+    model = SimpleNamespace(config=SimpleNamespace(pad_token_id=0))
+    tokenizer = SimpleNamespace(pad_token_id=151643)
+
+    _set_pad_token_id_if_missing(model, tokenizer)
+
+    assert model.config.pad_token_id == 0
+
+
+def test_set_pad_token_id_if_missing_tolerates_tokenizer_without_pad():
+    model = SimpleNamespace(config=SimpleNamespace(pad_token_id=None))
+    tokenizer = SimpleNamespace(pad_token_id=None)
+
+    _set_pad_token_id_if_missing(model, tokenizer)
+
+    assert model.config.pad_token_id is None


### PR DESCRIPTION
### What

`docs/lm_head_to_classifier/convert_lm.py` (lines 166-170) lists
`Qwen/Qwen3-Reranker-0.6B`, `-4B` and `-8B`, and the converted checkpoints are published
as `michaelfeil/Qwen3-Reranker-0.6B-seq` et al. Their `config.json` carries
`architectures: ["Qwen3ForSequenceClassification"]` and `id2label: {"0": "no", "1": "yes"}`
but **no `pad_token_id` key**.

transformers' decoder-only sequence-classification forward requires one as soon as the
batch is larger than 1:

```
ValueError: Cannot handle batch sizes > 1 if no padding token is defined.
```

infinity hits this during `loaded_engine.warmup(batch_size=engine_args.batch_size, ...)`
in `inference/select_model.py`, with the default `batch_size=32` — so the server fails
at load, before serving a single request.

`michaelfeil/mxbai-rerank-base-v2-seq` is unaffected because its config ships
`pad_token_id: 151643`, which is why this has gone unnoticed.

### Fix

Adopt the tokenizer's `pad_token_id` when the model config does not have one, right
after the `pipeline(...)` call and before quantization / BetterTransformer / compile
wrap the model. It is a strict no-op for every checkpoint that already carries the key.

The four lines live in a small module-level helper rather than inline so they can be
unit-tested without downloading a model — which matters here, because the test group
pins `transformers = "4.47.0"`, and that version cannot parse `model_type: qwen3` at all.

### Which path this touches

`inference/select_model.py` routes on label count: `len(id2label) < 2` goes to
`RerankEngine`, otherwise `PredictEngine`. These checkpoints have 2 labels, so they go
to `SentenceClassifier` and never reach `CrossEncoderPatched`. The crossencoder path is
therefore untouched — the 1-label rerankers that do reach it are BERT-family encoders
that always carry `pad_token_id`.

### Test

Three assertion-level tests appended to the existing
`tests/unit_test/transformer/classifier/test_torch_classifer.py`, using
`types.SimpleNamespace` stand-ins: missing -> adopted, already set -> untouched,
tokenizer has none -> no crash. No download, no torch, version-independent, so they run
on the pinned 4.47.0 in CI. No new model id added to `conftest.py`.

### Deliberately not in scope

No change to the `transformers` floor — I saw #620 was closed for exactly that reason
(ONNX-optimum and BetterTransformer breakage). No causal-LM reranker engine, no
server-side Qwen chat template, no rerank-API `instruction` field. This is only the
load-time crash.

Related to but does not close #642.

### Verified

Config of the published checkpoint (`michaelfeil/Qwen3-Reranker-0.6B-seq/raw/main/config.json`):

```
architectures : ['Qwen3ForSequenceClassification']
model_type    : qwen3
id2label      : {'0': 'no', '1': 'yes'}
pad_token_id  : ABSENT
```

versus `michaelfeil/mxbai-rerank-base-v2-seq`, which carries `pad_token_id: 151643` and works today.

Minimal reproduction, on this repo's own pinned `transformers==4.47.0`, no download required
(Qwen2 stands in for Qwen3 because 4.47.0 cannot parse `model_type: qwen3` — the defect is in
the shared decoder-only sequence-classification path, not in Qwen3 specifically):

```python
cfg = Qwen2Config(vocab_size=64, hidden_size=16, num_hidden_layers=1,
                  num_attention_heads=2, num_key_value_heads=2,
                  num_labels=2, pad_token_id=None)
m = Qwen2ForSequenceClassification(cfg).eval()
m(input_ids=torch.randint(0, 64, (2, 8)))
```
```
transformers 4.47.0
config.pad_token_id = None
ValueError: Cannot handle batch sizes > 1 if no padding token is defined.
after fix -> logits (2, 2)
```

Local test run (Windows, Python 3.11.9):

```
$ poetry run pytest tests/unit_test/transformer/classifier/test_torch_classifer.py -v
test_classifier PASSED                                                  [ 25%]
test_set_pad_token_id_if_missing_adopts_tokenizer_value PASSED          [ 50%]
test_set_pad_token_id_if_missing_is_noop_when_already_set PASSED        [ 75%]
test_set_pad_token_id_if_missing_tolerates_tokenizer_without_pad PASSED [100%]
4 passed in 18.71s
```

`ruff check` and `codespell` pass; `ruff format --check` does not flag either changed file;
`mypy ./infinity_emb` output is identical to `main`.

I have not benchmarked the converted checkpoint or verified score parity against the original
causal-LM model — this PR is only about the load-time crash.
